### PR TITLE
feat: portable build naming and PATH in installer

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -42,12 +42,28 @@ Name: "german"; MessagesFile: "compiler:Languages\German.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "build\bin\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "build\bin\mtui-portable.exe"; DestDir: "{app}"; DestName: "{#MyAppExeName}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Registry]
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Check: NeedsAddPath(ExpandConstant('{app}'))
+
+[Code]
+function NeedsAddPath(Param: string): boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OrigPath) then
+  begin
+    Result := True;
+    exit;
+  end;
+  Result := Pos(';' + Uppercase(Param) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
+end;
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/wails.json
+++ b/wails.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
   "name": "mtui",
-  "outputfilename": "mtui",
+  "outputfilename": "mtui-portable",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",


### PR DESCRIPTION
## Summary
- Build output renamed to `mtui-portable.exe` for the portable version
- Installer installs it as `mtui.exe` and adds install directory to user PATH
- Users can run `mtui` from any terminal after installation

## Test plan
- [x] `wails build` produces `mtui-portable.exe`
- [x] Inno Setup builds `mtui-setup-1.4.1.exe` successfully
- [ ] Install and verify `mtui` is available in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)