### PR TITLE
chore: rename Go module to Multiterminal-UI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/patrick-goecommerce/multiterminal
+module github.com/patrick-goecommerce/Multiterminal-UI
 
 go 1.24.0
 

--- a/installer.iss
+++ b/installer.iss
@@ -4,7 +4,7 @@
 #define MyAppName "Multiterminal UI"
 #define MyAppExeName "mtui.exe"
 #define MyAppPublisher "Patrick GoEcommerce"
-#define MyAppURL "https://github.com/patrick-goecommerce/multiterminal"
+#define MyAppURL "https://github.com/patrick-goecommerce/Multiterminal-UI"
 #define MyAppDescription "A terminal multiplexer for Claude Code power users"
 
 ; Version is passed via /DMyAppVersion=x.y.z on the command line.

--- a/internal/backend/app.go
+++ b/internal/backend/app.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/config"
-	"github.com/patrick-goecommerce/multiterminal/internal/terminal"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/config"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 

--- a/internal/backend/app_health.go
+++ b/internal/backend/app_health.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/config"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/config"
 )
 
 // HealthInfo is returned to the frontend on startup to indicate

--- a/internal/backend/app_health_test.go
+++ b/internal/backend/app_health_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/config"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/config"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/backend/app_queue_test.go
+++ b/internal/backend/app_queue_test.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"testing"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/terminal"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
 )
 
 func newTestApp() *App {

--- a/internal/backend/app_scan.go
+++ b/internal/backend/app_scan.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/terminal"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 

--- a/internal/backend/app_scan_extended_test.go
+++ b/internal/backend/app_scan_extended_test.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"testing"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/terminal"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/backend/app_scan_test.go
+++ b/internal/backend/app_scan_test.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"testing"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/terminal"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
 )
 
 // ---------------------------------------------------------------------------

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/patrick-goecommerce/multiterminal/internal/backend"
-	"github.com/patrick-goecommerce/multiterminal/internal/config"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/backend"
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/config"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/logger"
 	"github.com/wailsapp/wails/v2/pkg/options"


### PR DESCRIPTION
## Summary
- Update Go module path from `multiterminal` to `Multiterminal-UI` to match renamed repo
- Update all import paths across 10 files
- Update installer URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)