### PR TITLE
feat: version display in title bar + update check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
 
       - name: Build Windows amd64
-        run: wails build
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          wails build -ldflags "-X github.com/patrick-goecommerce/Multiterminal-UI/internal/backend.Version=$VERSION"
 
       - name: Extract version from tag
         id: version
@@ -35,7 +38,7 @@ jobs:
 
       - name: Rename portable binary
         shell: bash
-        run: mv build/bin/mtui.exe "mtui-portable-${{ steps.version.outputs.version }}.exe"
+        run: mv build/bin/mtui-portable.exe "mtui-portable-${{ steps.version.outputs.version }}.exe"
 
       - name: Build installer
         run: iscc /DMyAppVersion=${{ steps.version.outputs.version }} installer.iss

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -33,6 +33,9 @@
   let issueCount = 0;
   let branch = '';
   let commitAgeMinutes = -1;
+  let updateAvailable = false;
+  let latestVersion = '';
+  let downloadURL = '';
 
   let branchInterval: ReturnType<typeof setInterval> | null = null;
   let commitAgeInterval: ReturnType<typeof setInterval> | null = null;
@@ -115,6 +118,14 @@
       const health = await App.CheckHealth();
       if (health.crash_detected && !health.logging_enabled) showCrashDialog = true;
     } catch {}
+
+    App.CheckForUpdates().then((info) => {
+      if (info.updateAvailable) {
+        updateAvailable = true;
+        latestVersion = info.latestVersion;
+        downloadURL = info.downloadURL;
+      }
+    }).catch(() => {});
 
     const restored = await restoreSession();
     if (!restored) {
@@ -336,7 +347,7 @@
     />
   </div>
 
-  <Footer {branch} {totalCost} {tabInfo} {commitAgeMinutes} />
+  <Footer {branch} {totalCost} {tabInfo} {commitAgeMinutes} {updateAvailable} {latestVersion} {downloadURL} />
   <LaunchDialog visible={showLaunchDialog} on:launch={handleLaunch} on:close={() => (showLaunchDialog = false)} />
   <ProjectDialog visible={showProjectDialog} on:create={handleProjectCreate} on:close={() => (showProjectDialog = false)} />
   <SettingsDialog visible={showSettingsDialog} on:close={() => (showSettingsDialog = false)} />

--- a/frontend/src/components/Footer.svelte
+++ b/frontend/src/components/Footer.svelte
@@ -3,6 +3,9 @@
   export let totalCost: string = '';
   export let tabInfo: string = '';
   export let commitAgeMinutes: number = -1;
+  export let updateAvailable: boolean = false;
+  export let latestVersion: string = '';
+  export let downloadURL: string = '';
 
   $: commitLabel = (() => {
     if (commitAgeMinutes < 0) return '';
@@ -38,6 +41,13 @@
   <div class="footer-center">
     {#if commitLabel}
       <span class="commit-age {commitClass}">{commitLabel}</span>
+    {/if}
+  </div>
+  <div class="footer-update">
+    {#if updateAvailable && downloadURL}
+      <a class="update-link" href={downloadURL} target="_blank" rel="noopener">
+        Update v{latestVersion} verfügbar
+      </a>
     {/if}
   </div>
   <div class="footer-right">
@@ -111,6 +121,28 @@
   @keyframes commit-pulse {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }
+  }
+
+  .footer-update {
+    display: flex;
+    align-items: center;
+  }
+
+  .update-link {
+    color: #22c55e;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 12px;
+    animation: update-pulse 2s ease-in-out infinite;
+  }
+
+  .update-link:hover {
+    text-decoration: underline;
+  }
+
+  @keyframes update-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
   }
 
   .shortcut {

--- a/internal/backend/app_version.go
+++ b/internal/backend/app_version.go
@@ -1,0 +1,78 @@
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Version is the application version. It is set at build time via ldflags:
+//
+//	-ldflags "-X github.com/patrick-goecommerce/Multiterminal-UI/internal/backend.Version=1.5.0"
+//
+// When not set, it defaults to "dev".
+var Version = "dev"
+
+// UpdateInfo holds the result of a GitHub release check.
+type UpdateInfo struct {
+	CurrentVersion  string `json:"currentVersion"`
+	LatestVersion   string `json:"latestVersion"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	DownloadURL     string `json:"downloadURL"`
+}
+
+// GetAppVersion returns the current application version string.
+func (a *App) GetAppVersion() string {
+	return Version
+}
+
+// CheckForUpdates queries the GitHub releases API and compares the latest
+// release tag with the current version.
+func (a *App) CheckForUpdates() UpdateInfo {
+	info := UpdateInfo{CurrentVersion: Version}
+
+	if Version == "dev" {
+		return info
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/patrick-goecommerce/Multiterminal-UI/releases/latest")
+	if err != nil {
+		return info
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return info
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return info
+	}
+
+	latest := strings.TrimPrefix(release.TagName, "v")
+	info.LatestVersion = latest
+	info.DownloadURL = release.HTMLURL
+	info.UpdateAvailable = latest != "" && normalizeVersion(latest) != normalizeVersion(Version)
+
+	return info
+}
+
+// normalizeVersion strips a leading "v" and returns the bare semver string.
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// VersionTitle returns the window title including the version.
+func VersionTitle() string {
+	if Version == "dev" {
+		return "Multiterminal UI dev"
+	}
+	return fmt.Sprintf("Multiterminal UI v%s", normalizeVersion(Version))
+}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	log.Println("App created, starting Wails...")
 
 	err := wails.Run(&options.App{
-		Title:            "Multiterminal UI",
+		Title:            backend.VersionTitle(),
 		Width:            1400,
 		Height:           900,
 		MinWidth:         800,

--- a/wails.json
+++ b/wails.json
@@ -12,7 +12,7 @@
   "info": {
     "companyName": "",
     "productName": "Multiterminal UI",
-    "productVersion": "1.3.0",
+    "productVersion": "1.5.0",
     "copyright": "",
     "comments": "A terminal multiplexer for Claude Code power users"
   }


### PR DESCRIPTION
## Summary
- Show app version in window title bar (e.g. "Multiterminal UI v1.5.0" or "Multiterminal UI dev")
- Check GitHub releases on startup and show update link in footer when newer version available
- Fix release workflow: inject version via ldflags + correct portable binary rename path (`mtui-portable.exe`)
- Bump `productVersion` to 1.5.0

## Test plan
- [ ] `wails build` → title bar shows "Multiterminal UI dev"
- [ ] Build with `-ldflags "-X .../backend.Version=1.5.0"` → title shows "Multiterminal UI v1.5.0"
- [ ] Footer shows green pulsing "Update vX.Y.Z verfügbar" link when newer release exists
- [ ] No update hint shown for dev builds or when already on latest version
- [ ] Release workflow builds correctly with version injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)