### PR TITLE
fix: swap installer and rename steps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
         shell: bash
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Build installer
+        run: iscc /DMyAppVersion=${{ steps.version.outputs.version }} installer.iss
+
       - name: Rename portable binary
         shell: bash
         run: mv build/bin/mtui-portable.exe "mtui-portable-${{ steps.version.outputs.version }}.exe"
-
-      - name: Build installer
-        run: iscc /DMyAppVersion=${{ steps.version.outputs.version }} installer.iss
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- The installer reads `build/bin/mtui-portable.exe` as its source file
- The rename step was running **before** the installer, moving the file away
- Swapped the order: installer builds first, then the portable binary gets renamed

## Test plan
- [ ] Release workflow completes successfully (both installer and portable binary produced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)