### PR TITLE
fix: resolve Windows path issues in tests and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test

--- a/internal/backend/app_health.go
+++ b/internal/backend/app_health.go
@@ -58,6 +58,7 @@ func (a *App) DisableLogging() {
 	_ = config.SaveHealth(a.health)
 
 	log.SetOutput(os.Stderr)
+	closeLogFile()
 	log.Println("[DisableLogging] Logging disabled, output reset to stderr")
 }
 
@@ -77,16 +78,32 @@ func logFilePath() string {
 	return filepath.Join(dir, fmt.Sprintf("multiterminal-%s.log", ts))
 }
 
+// logFile holds the currently open log file so it can be closed when switching or disabling.
+var logFile *os.File
+
 // setupFileLogging redirects log output to the given file path.
 func setupFileLogging(path string) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return err
 	}
+	// Close previous log file if open
+	if logFile != nil {
+		logFile.Close()
+	}
+	logFile = f
 	// Write to both file and stderr for visibility
 	w := io.MultiWriter(os.Stderr, f)
 	log.SetOutput(w)
 	return nil
+}
+
+// closeLogFile closes the current log file handle if open.
+func closeLogFile() {
+	if logFile != nil {
+		logFile.Close()
+		logFile = nil
+	}
 }
 
 // InitLoggingFromConfig sets up file logging if the config says it's enabled.

--- a/internal/backend/app_health_test.go
+++ b/internal/backend/app_health_test.go
@@ -82,6 +82,7 @@ func TestEnableLogging_Manual(t *testing.T) {
 	}
 	defer f.Close()
 	defer log.SetOutput(os.Stderr) // restore after test
+	defer closeLogFile()
 
 	// Enable logging manually (auto=false)
 	result := app.EnableLogging(false)
@@ -105,6 +106,7 @@ func TestEnableLogging_Auto(t *testing.T) {
 		health: config.HealthState{CleanSinceAuto: 5},
 	}
 	defer log.SetOutput(os.Stderr)
+	defer closeLogFile()
 
 	result := app.EnableLogging(true)
 
@@ -198,6 +200,7 @@ func TestSetupFileLogging_WritesToFile(t *testing.T) {
 	path := filepath.Join(dir, "test-setup.log")
 
 	defer log.SetOutput(os.Stderr)
+	defer closeLogFile()
 
 	err := setupFileLogging(path)
 	if err != nil {
@@ -255,6 +258,7 @@ func TestLoggingEnableDisableCycle(t *testing.T) {
 		health: config.HealthState{},
 	}
 	defer log.SetOutput(os.Stderr)
+	defer closeLogFile()
 
 	// Enable auto-logging
 	result := app.EnableLogging(true)


### PR DESCRIPTION
## Summary
- **Fix `markParentDirs`**: Replace `filepath.Abs` with `filepath.Clean` to avoid Windows drive-prefix on Unix-style paths
- **Fix `GetGitFileStatuses`**: Normalize git's repo root with `filepath.FromSlash` + `filepath.EvalSymlinks` to handle MSYS paths and Windows 8.3 short names
- **Fix `setupFileLogging`**: Track open log file handle in package variable, close on switch/disable to prevent TempDir cleanup failures on Windows
- **Add CI workflow** (`.github/workflows/ci.yml`): Go build/vet/test on `windows-latest`, frontend build/test on `ubuntu-latest`, triggered on PRs and pushes to `main`

## Test plan
- [ ] `go test ./...` passes on Windows (all 3 previously failing tests now green)
- [ ] `go vet ./...` reports no warnings
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)