### PR TITLE
release: v1.16.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mtui-frontend",
   "private": true,
-  "version": "1.16.1",
+  "version": "1.16.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wails.json
+++ b/wails.json
@@ -12,7 +12,7 @@
   "info": {
     "companyName": "",
     "productName": "Multiterminal UI",
-    "productVersion": "1.16.1",
+    "productVersion": "1.16.2",
     "copyright": "",
     "comments": "A terminal multiplexer for Claude Code power users"
   }


### PR DESCRIPTION
## Summary
- Bump version to 1.16.2
- Includes CI fixes (tracked wailsjs bindings, frontend/dist stub for go:embed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)