### PR TITLE
fix: include installer in GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,18 @@ jobs:
       - name: Build installer
         run: iscc /DMyAppVersion=${{ steps.version.outputs.version }} installer.iss
 
-      - name: Rename portable binary
+      - name: Stage release artifacts
         shell: bash
-        run: mv build/bin/mtui-portable.exe "mtui-portable-${{ steps.version.outputs.version }}.exe"
+        run: |
+          mv build/bin/mtui-portable.exe "mtui-portable-${{ steps.version.outputs.version }}.exe"
+          mv installer-output/mtui-setup-${{ steps.version.outputs.version }}.exe .
 
       - uses: actions/upload-artifact@v4
         with:
           name: mtui-windows
           path: |
             mtui-portable-*.exe
-            installer-output/mtui-setup-*.exe
+            mtui-setup-*.exe
 
   release:
     needs: [build-windows]


### PR DESCRIPTION
## Summary
- Move setup exe out of `installer-output/` before artifact upload
- Fixes: `upload-artifact` preserved the subdirectory path, so `download-artifact` + `merge-multiple` placed it at `artifacts/installer-output/mtui-setup-*.exe` instead of `artifacts/mtui-setup-*.exe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)