### PR TITLE
fix: preserve terminal scrollback across tab switches

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -464,17 +464,24 @@
 
   <div class="content">
     <Sidebar visible={showSidebar} dir={$activeTab?.dir ?? ''} {issueCount} {paneIssues} {conflictFiles} {conflictOperation} initialView={sidebarView} on:close={() => (showSidebar = false)} on:selectFile={handleSidebarFile} on:createIssue={handleCreateIssue} on:editIssue={handleEditIssue} on:launchForIssue={handleLaunchForIssue} />
-    <PaneGrid
-      panes={$activeTab?.panes ?? []}
-      on:closePane={handleClosePane}
-      on:maximizePane={handleMaximizePane}
-      on:focusPane={handleFocusPane}
-      on:renamePane={handleRenamePane}
-      on:restartPane={handleRestartPane}
-      on:issueAction={handleIssueAction}
-      on:navigateFile={handleNavigateFile}
-      on:splitPane={() => (showLaunchDialog = true)}
-    />
+    <div class="tab-layers">
+      {#each $allTabs as tab (tab.id)}
+        <div class="tab-layer" class:active={tab.id === $activeTab?.id}>
+          <PaneGrid
+            panes={tab.panes}
+            active={tab.id === $activeTab?.id}
+            on:closePane={handleClosePane}
+            on:maximizePane={handleMaximizePane}
+            on:focusPane={handleFocusPane}
+            on:renamePane={handleRenamePane}
+            on:restartPane={handleRestartPane}
+            on:issueAction={handleIssueAction}
+            on:navigateFile={handleNavigateFile}
+            on:splitPane={() => (showLaunchDialog = true)}
+          />
+        </div>
+      {/each}
+    </div>
   </div>
 
   <Footer {branch} {totalCost} {tabInfo} {commitAgeMinutes} {conflictCount} {conflictOperation} />
@@ -504,4 +511,11 @@
   }
   .app { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
   .content { display: flex; flex: 1; overflow: hidden; }
+  .tab-layers { position: relative; flex: 1; overflow: hidden; }
+  .tab-layer {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column;
+    visibility: hidden; pointer-events: none;
+  }
+  .tab-layer.active { visibility: visible; pointer-events: auto; }
 </style>

--- a/frontend/src/components/PaneGrid.svelte
+++ b/frontend/src/components/PaneGrid.svelte
@@ -4,6 +4,7 @@
   import type { Pane } from '../stores/tabs';
 
   export let panes: Pane[] = [];
+  export let active: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -51,6 +52,7 @@
   {#each visiblePanes as pane (pane.id)}
     <TerminalPane
       {pane}
+      {active}
       paneIndex={panes.indexOf(pane) + 1}
       on:close={handleClose}
       on:maximize={handleMaximize}

--- a/internal/backend/app.go
+++ b/internal/backend/app.go
@@ -280,7 +280,7 @@ func (a *App) SelectDirectory(startDir string) string {
 // (which produce many small chunks) arrive as a single event, preventing
 // cursor flicker in xterm.js.
 func (a *App) streamOutput(id int, sess *terminal.Session) {
-	const coalesceDelay = 4 * time.Millisecond
+	const coalesceDelay = 8 * time.Millisecond
 	for {
 		select {
 		case data, ok := <-sess.RawOutputCh:


### PR DESCRIPTION
## Summary
- **Tab-Layering:** Render all tabs simultaneously with CSS absolute positioning. Active tab visible, inactive tabs use `visibility: hidden` — xterm.js instances stay alive with full scrollback buffer and event handlers
- **Output buffering:** Buffer PTY output until xterm.js is fitted to real pane size (`isReady` flag), preventing cursor-hopping from 24x80 → actual dimensions
- **Cursor fix:** Smart DECTCEM state tracking across output batches — hides cursor during writes but restores the app's intended show/hide state afterward
- **Scrollbar CSS:** Force visible scrollbar in WebView2 via `::-webkit-scrollbar` rules (Windows 11 overlay scrollbars auto-hide)
- **Auto re-focus:** Terminal automatically gets keyboard focus when switching back to its tab

## Test plan
- [ ] Open multiple tabs with terminals, switch between them — scrollback history preserved
- [ ] Terminal output continues flowing in background tabs (no lost output)
- [ ] After tab switch, typing works immediately (auto-focus)
- [ ] Scrollbar always visible when there's content to scroll
- [ ] No cursor-hopping on new terminal start
- [ ] No ghost/double cursors during TUI output (Claude Code status lines)
- [ ] Window resize works correctly for all tabs (active and inactive)
- [ ] Session restore on app restart still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)