### PR TITLE
chore: bump version to 1.17.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mtui-frontend",
   "private": true,
-  "version": "1.16.2",
+  "version": "1.17.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Version bump to 1.17.3 for bugfix release

## Changes
- `frontend/package.json`: version 1.16.2 → 1.17.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)