### PR TITLE
fix: reliable terminal pane focus on click

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mtui-frontend",
-  "version": "1.16.2",
+  "version": "1.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mtui-frontend",
-      "version": "1.16.2",
+      "version": "1.17.3",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.16.0",

--- a/frontend/src/components/TerminalPane.svelte
+++ b/frontend/src/components/TerminalPane.svelte
@@ -138,6 +138,10 @@
       return true;
     });
 
+    termInstance.terminal.onFocus(() => {
+      dispatch('focus', { paneId: pane.id });
+    });
+
     termInstance.terminal.onData((data: string) => {
       const encoder = new TextEncoder();
       const bytes = encoder.encode(data);
@@ -376,7 +380,7 @@
   class:activity-done={pane.activity === 'done'}
   class:activity-needs-input={pane.activity === 'needsInput'}
   class:drop-target={dropHighlight}
-  on:click={() => dispatch('focus', { paneId: pane.id })}
+  on:mousedown={() => dispatch('focus', { paneId: pane.id })}
   on:dragover={handleDragOver}
   on:dragleave={handleDragLeave}
   on:drop={handleDrop}


### PR DESCRIPTION
## Summary
- Ersetzt `on:click` durch `on:mousedown` auf dem Terminal-Pane-Container — `mousedown` feuert sofort und wird nicht von `stopPropagation` der Titlebar-Buttons blockiert
- Fügt `terminal.onFocus()` Listener hinzu als Backup, wenn xterm.js direkt den Fokus erhält (Klick auf Canvas)
- Behebt das intermittierende Problem, dass der farbige Fokus-Rahmen nach einem Klick nicht erscheint

## Test plan
- [ ] Mehrere Terminals öffnen, zwischen ihnen per Klick wechseln — Fokus-Rahmen muss zuverlässig erscheinen
- [ ] Klick auf Titlebar-Buttons (Close, Maximize, Queue) — Pane muss vorher fokussiert werden
- [ ] Klick direkt auf die xterm.js-Fläche — Fokus-Rahmen muss sofort erscheinen
- [ ] Schnelle Klicks zwischen Panes — kein verlorener Fokus

🤖 Generated with [Claude Code](https://claude.com/claude-code)