### PR TITLE
fix: eliminate terminal flicker from overlapping flush cycles

### DIFF
--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -68,7 +68,7 @@ func NewSession(id, rows, cols int) *Session {
 		Screen:      NewScreen(rows, cols),
 		Status:      StatusRunning,
 		OutputCh:    make(chan struct{}, 1),
-		RawOutputCh: make(chan []byte, 64),
+		RawOutputCh: make(chan []byte, 256),
 		done:        make(chan struct{}),
 	}
 }


### PR DESCRIPTION
## Summary
- **Remove redundant `requestAnimationFrame` wrapper** from terminal output flush — xterm.js already batches rendering internally via its own rAF loop. The extra rAF caused overlapping flush cycles where `flushTimer` was reset before the rAF callback executed, allowing new timers to queue multiple writes per frame.
- **Replace `flushTimer` with `flushScheduled` flag** that stays true until the write completes, ensuring at most one `terminal.write()` per 16ms window.
- **Increase `RawOutputCh` buffer from 64 to 256** to prevent silent data drops under heavy PTY output.

## Test plan
- [ ] Run Claude Code in a Multiterminal pane and observe task list updates (phases, thinking indicators) — no more flickering
- [ ] Verify interactive typing latency is unchanged
- [ ] Test with multiple panes producing heavy output simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)