### PR TITLE
fix: chunked PTY writes to prevent large paste input loss

### DIFF
--- a/frontend/src/components/TerminalPane.svelte
+++ b/frontend/src/components/TerminalPane.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, createEventDispatcher } from 'svelte';
   import { createTerminal, getTerminalTheme, buildFontFamily } from '../lib/terminal';
   import { pasteToSession, copySelection, writeTextToSession } from '../lib/clipboard';
+  import { encodeForPty } from '../lib/claude';
   import { sendNotification } from '../lib/notifications';
   import { playBell, audioMuted } from '../lib/audio';
   import { tabStore, type Pane } from '../stores/tabs';
@@ -140,9 +141,7 @@
     });
 
     termInstance.terminal.onData((data: string) => {
-      const encoder = new TextEncoder();
-      const bytes = encoder.encode(data);
-      App.WriteToSession(pane.sessionId, btoa(String.fromCharCode(...bytes)));
+      App.WriteToSession(pane.sessionId, encodeForPty(data));
     });
 
     // Batch PTY output writes with a short time window to reduce render overhead.


### PR DESCRIPTION
## Summary
- Large clipboard pastes (>30 lines) were silently truncated because the entire input was written to ConPTY in a single call, overflowing the kernel buffer
- PTY writes are now chunked (1KB) with partial-write retry and a 1ms yield between chunks
- Fixes potential stack overflow from spread operator (`...bytes`) on large arrays in `onData` handler by reusing `encodeForPty()`
- Increases output channel buffer from 64 to 256 to prevent echo data loss during large pastes

## Test plan
- [ ] Paste 30+ lines into a shell pane — all lines should appear
- [ ] Paste 100+ lines into a shell pane — all lines should appear
- [ ] Paste 200+ lines into a Claude Code pane — input should be accepted on first try
- [ ] Normal typing and small pastes should still work without noticeable delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)