### PR TITLE
fix: font size slider not draggable in settings

### DIFF
--- a/frontend/src/components/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog.svelte
@@ -96,10 +96,6 @@
     config.update(c => ({ ...c, font_family: fontFamily }));
   }
 
-  function handleFontSizeChange() {
-    config.update(c => ({ ...c, font_size: fontSize }));
-  }
-
   async function detectClaude() {
     try {
       const result = await App.DetectClaudePath();
@@ -238,7 +234,7 @@
         <label class="setting-label" for="font-size">Schriftgröße</label>
         <p class="setting-desc">Basis-Schriftgröße in Pixel (8–32). Ctrl+Scroll zum Zoomen pro Pane.</p>
         <div class="volume-row">
-          <input id="font-size" type="range" min="8" max="32" step="1" bind:value={fontSize} on:input={handleFontSizeChange} class="volume-slider" />
+          <input id="font-size" type="range" min="8" max="32" step="1" bind:value={fontSize} class="volume-slider" />
           <span class="volume-value">{fontSize}px</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Entfernt den `on:input={handleFontSizeChange}` Handler vom Schriftgrößen-Slider
- Der Handler hat bei jedem Drag-Event `config.update()` aufgerufen, was den reaktiven `$: if (visible)` Block getriggert hat
- Dieser Block rief `dialogEl.focus()` auf, was den Fokus vom Slider gestohlen und die Drag-Interaktion unterbrochen hat
- Schriftgröße wird jetzt nur beim Speichern übernommen (wie der Lautstärke-Slider)

## Test plan
- [ ] Settings öffnen → Schriftgröße-Slider ziehen → Wert ändert sich flüssig
- [ ] Speichern → Terminals übernehmen neue Schriftgröße
- [ ] Abbrechen → Schriftgröße bleibt unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)