### PR TITLE
fix: replace font size slider with dropdown

### DIFF
--- a/frontend/src/components/SettingsDialog.svelte
+++ b/frontend/src/components/SettingsDialog.svelte
@@ -41,7 +41,7 @@
   let audioErrorSound = $config.audio?.error_sound || '';
 
   let fontFamily = $config.font_family || '';
-  let fontSize = $config.font_size || 14;
+  let fontSize = $config.font_size || 10;
   let savedFontFamily = fontFamily;
   let savedFontSize = fontSize;
   let availableFonts: { name: string; available: boolean }[] = [];
@@ -61,7 +61,7 @@
     audioInputSound = $config.audio?.input_sound || '';
     audioErrorSound = $config.audio?.error_sound || '';
     fontFamily = $config.font_family || '';
-    fontSize = $config.font_size || 14;
+    fontSize = $config.font_size || 10;
     savedFontFamily = fontFamily;
     savedFontSize = fontSize;
     availableFonts = MONOSPACE_FONTS.map(name => ({
@@ -166,7 +166,7 @@
 
   function close() {
     applyTheme(savedTheme, $config.terminal_color || '#39ff14');
-    config.update(c => ({ ...c, font_family: savedFontFamily, font_size: savedFontSize }));
+    config.update(c => ({ ...c, font_family: savedFontFamily, font_size: savedFontSize || 10 }));
     dispatch('close');
   }
 
@@ -175,8 +175,8 @@
     selectedTheme = 'dark';
     applyTheme('dark', '#39ff14');
     fontFamily = '';
-    fontSize = 14;
-    config.update(c => ({ ...c, font_family: '', font_size: 14 }));
+    fontSize = 10;
+    config.update(c => ({ ...c, font_family: '', font_size: 10 }));
     audioEnabled = true;
     audioWhenFocused = true;
     audioVolume = 50;
@@ -232,11 +232,12 @@
 
       <div class="setting-group">
         <label class="setting-label" for="font-size">Schriftgröße</label>
-        <p class="setting-desc">Basis-Schriftgröße in Pixel (8–32). Ctrl+Scroll zum Zoomen pro Pane.</p>
-        <div class="volume-row">
-          <input id="font-size" type="range" min="8" max="32" step="1" bind:value={fontSize} class="volume-slider" />
-          <span class="volume-value">{fontSize}px</span>
-        </div>
+        <p class="setting-desc">Basis-Schriftgröße in Pixel. Ctrl+Scroll zum Zoomen pro Pane.</p>
+        <select id="font-size" class="theme-select" bind:value={fontSize}>
+          {#each [8, 10, 12, 14, 16, 18, 20] as size}
+            <option value={size}>{size}px</option>
+          {/each}
+        </select>
       </div>
 
       <div class="setting-group">

--- a/frontend/src/components/TerminalPane.svelte
+++ b/frontend/src/components/TerminalPane.svelte
@@ -106,7 +106,7 @@
   }
 
   onMount(() => {
-    termInstance = createTerminal($currentTheme, handleLink, $config.font_family, ($config.font_size || 14) + (pane.zoomDelta || 0));
+    termInstance = createTerminal($currentTheme, handleLink, $config.font_family, ($config.font_size || 10) + (pane.zoomDelta || 0));
     termInstance.terminal.open(containerEl);
 
     requestAnimationFrame(() => {
@@ -269,7 +269,7 @@
     wheelHandler = (e: WheelEvent) => {
       if (!e.ctrlKey || !termInstance) return;
       e.preventDefault();
-      const baseSize = $config.font_size || 14;
+      const baseSize = $config.font_size || 10;
       const currentDelta = pane.zoomDelta || 0;
       const newDelta = e.deltaY < 0 ? currentDelta + 1 : currentDelta - 1;
       const effectiveSize = baseSize + newDelta;
@@ -340,7 +340,7 @@
   }
 
   $: if (termInstance && $config) {
-    const effectiveSize = ($config.font_size || 14) + (pane.zoomDelta || 0);
+    const effectiveSize = ($config.font_size || 10) + (pane.zoomDelta || 0);
     const clampedSize = Math.max(8, Math.min(32, effectiveSize));
     const newFamily = buildFontFamily($config.font_family);
 

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -177,7 +177,7 @@ export function createTerminal(
   const terminal = new Terminal({
     ...baseOptions,
     fontFamily: buildFontFamily(fontFamily || ''),
-    fontSize: fontSize || 14,
+    fontSize: fontSize || 10,
     theme: terminalThemes[theme] || terminalThemes.dark,
   });
 

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -70,6 +70,6 @@ export const config = writable<AppConfig>({
   localhost_auto_open: 'notify',
   sidebar_pinned: false,
   font_family: '',
-  font_size: 14,
+  font_size: 10,
   favorites: {},
 });

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,7 @@ func DefaultConfig() Config {
 		},
 		LocalhostAutoOpen: "notify",
 		FontFamily:        "",
-		FontSize:          14,
+		FontSize:          10,
 	}
 }
 
@@ -209,11 +209,9 @@ func Load() Config {
 		cfg.LocalhostAutoOpen = "notify"
 	}
 
-	if cfg.FontSize < 8 {
-		cfg.FontSize = 8
-	}
-	if cfg.FontSize > 32 {
-		cfg.FontSize = 32
+	validFontSizes := map[int]bool{8: true, 10: true, 12: true, 14: true, 16: true, 18: true, 20: true}
+	if !validFontSizes[cfg.FontSize] {
+		cfg.FontSize = 10
 	}
 
 	if cfg.Favorites == nil {


### PR DESCRIPTION
## Summary
- Defekten Schriftgrößen-Slider (kein Drag, keine Eingabe möglich) durch ein Dropdown-Select ersetzt
- Feste Größen: 8, 10, 12, 14, 16, 18, 20px
- Default-Schriftgröße von 14 auf 10 geändert (Frontend + Backend)

## Test plan
- [ ] Settings öffnen → Dropdown statt Slider sichtbar
- [ ] Schriftgröße im Dropdown ändern → Speichern → Terminals aktualisieren sich
- [ ] Ctrl+Scroll Zoom pro Pane funktioniert weiterhin
- [ ] Default zurücksetzen → Schriftgröße wird auf 10px gesetzt

🤖 Generated with [Claude Code](https://claude.com/claude-code)