### PR TITLE
feat(statusline): capture official Claude cost/context/model per pane

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -64,6 +64,11 @@ jobs:
             -info build/windows/info.json \
             -out wails_windows_amd64.syso
 
+      - name: Build statusline-forward shim (embedded into the main binary)
+        shell: bash
+        run: |
+          go build -o internal/backend/statusline-forward.exe ./cmd/statusline-forward
+
       - name: Build Go binary
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ FEATURE_IDEAS.md
 .mtui/kanban_fixed.json
 .superpowers/
 tmux-shim.exe
+# Embedded statusline-forward shim — built into internal/backend/ by the release
+# pipeline before the production build, then embedded via go:embed. Never committed.
+internal/backend/statusline-forward.exe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,9 @@ wails build            # Production build
 wails build -debug     # Debug build (with devtools)
 # Binary: build/bin/mtui-portable.exe (Windows)
 ```
+> **`-tags production` requires a pre-built shim.** `internal/backend/statusline_shim_embed.go`
+> embeds `statusline-forward.exe`, which is `.gitignored` and only produced by the release
+> workflow. Plain `go build` / `wails` builds use the dev (sibling-binary) path and work fine.
 
 ## Testing
 ```bash

--- a/cmd/statusline-forward/hide_other.go
+++ b/cmd/statusline-forward/hide_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+import "os/exec"
+
+// hideChildWindow is a no-op on non-Windows platforms (no console windows).
+func hideChildWindow(_ *exec.Cmd) {}

--- a/cmd/statusline-forward/hide_windows.go
+++ b/cmd/statusline-forward/hide_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// hideChildWindow sets CREATE_NO_WINDOW so the wrapped statusline command
+// (powershell) does not flash a console window each time Claude renders its
+// status line. Mirrors internal/backend.hideConsole. Safe for stdout-captured
+// children — it only suppresses console-window creation, not the stdio pipes.
+func hideChildWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= 0x08000000 // CREATE_NO_WINDOW
+}

--- a/cmd/statusline-forward/hide_windows_test.go
+++ b/cmd/statusline-forward/hide_windows_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestHideChildWindowSetsNoWindowFlag(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "echo")
+	hideChildWindow(cmd)
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&0x08000000 == 0 {
+		t.Fatalf("CREATE_NO_WINDOW (0x08000000) not set on SysProcAttr = %+v", cmd.SysProcAttr)
+	}
+}

--- a/cmd/statusline-forward/main.go
+++ b/cmd/statusline-forward/main.go
@@ -16,6 +16,8 @@ import (
 )
 
 func main() {
+	// Error deliberately ignored: a read failure yields an empty payload, which
+	// forward() handles gracefully, and must never break the wrapped statusline.
 	data, _ := io.ReadAll(os.Stdin)
 	// Display first: relay the wrapped statusline so the POST never delays it.
 	code := runWrapped(os.Args[1:], data, os.Stdout, os.Stderr)

--- a/cmd/statusline-forward/main.go
+++ b/cmd/statusline-forward/main.go
@@ -34,6 +34,7 @@ func runWrapped(args []string, stdin []byte, stdout, stderr io.Writer) int {
 	cmd.Stdin = bytes.NewReader(stdin)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	hideChildWindow(cmd) // prevent a console window flashing on each statusline render (Windows)
 	if err := cmd.Run(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			return ee.ExitCode()

--- a/cmd/statusline-forward/main.go
+++ b/cmd/statusline-forward/main.go
@@ -1,0 +1,69 @@
+// Command statusline-forward wraps a Claude Code statusLine command: it relays
+// the wrapped command's output (so the displayed status line is unchanged) and
+// fire-and-forget POSTs Claude's statusline JSON to MTUI for telemetry capture.
+// It must never block or break the wrapped statusline.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+func main() {
+	data, _ := io.ReadAll(os.Stdin)
+	// Display first: relay the wrapped statusline so the POST never delays it.
+	code := runWrapped(os.Args[1:], data, os.Stdout, os.Stderr)
+	// Then capture, best-effort.
+	forward(data, os.Getenv("MTUI_PORT"), os.Getenv("MULTITERMINAL_SESSION_ID"))
+	os.Exit(code)
+}
+
+// runWrapped runs args[0] with args[1:], feeding stdin and relaying stdout/stderr.
+// Returns the wrapped process exit code (0 when there is no wrapped command).
+func runWrapped(args []string, stdin []byte, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return 0
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = bytes.NewReader(stdin)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return ee.ExitCode()
+		}
+		return 1
+	}
+	return 0
+}
+
+// forward POSTs the raw statusline JSON to MTUI. Silent on any failure.
+func forward(payload []byte, port, sid string) {
+	if port == "" || sid == "" {
+		return
+	}
+	id, err := strconv.Atoi(sid)
+	if err != nil {
+		return
+	}
+	body, err := json.Marshal(struct {
+		SessionID int             `json:"sessionId"`
+		Payload   json.RawMessage `json:"payload"`
+	}{SessionID: id, Payload: json.RawMessage(payload)})
+	if err != nil {
+		return
+	}
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Post("http://127.0.0.1:"+port+"/api/statusline",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/cmd/statusline-forward/main_test.go
+++ b/cmd/statusline-forward/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -41,7 +42,7 @@ func TestForwardPostsSessionIdAndPayload(t *testing.T) {
 		ch <- g
 	}))
 	defer srv.Close()
-	port := strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+	_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
 
 	forward([]byte(`{"cost":{"total_cost_usd":0.42}}`), port, "7")
 

--- a/cmd/statusline-forward/main_test.go
+++ b/cmd/statusline-forward/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunWrappedPassesThroughStdoutAndExit(t *testing.T) {
+	var out bytes.Buffer
+	// `cmd /c echo hi` prints "hi"; exit 0.
+	code := runWrapped([]string{"cmd", "/c", "echo", "hi"}, []byte("{}"), &out, io.Discard)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "hi") {
+		t.Fatalf("stdout = %q, want it to contain %q", out.String(), "hi")
+	}
+}
+
+func TestRunWrappedNoArgsIsNoop(t *testing.T) {
+	var out bytes.Buffer
+	if code := runWrapped(nil, []byte("{}"), &out, io.Discard); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+}
+
+func TestForwardPostsSessionIdAndPayload(t *testing.T) {
+	type got struct {
+		SessionID int             `json:"sessionId"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	ch := make(chan got, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var g got
+		_ = json.NewDecoder(r.Body).Decode(&g)
+		ch <- g
+	}))
+	defer srv.Close()
+	port := strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+
+	forward([]byte(`{"cost":{"total_cost_usd":0.42}}`), port, "7")
+
+	select {
+	case g := <-ch:
+		if g.SessionID != 7 {
+			t.Fatalf("sessionId = %d, want 7", g.SessionID)
+		}
+		if !strings.Contains(string(g.Payload), "0.42") {
+			t.Fatalf("payload = %s, want it to contain 0.42", g.Payload)
+		}
+	default:
+		t.Fatal("server received no request")
+	}
+}
+
+func TestForwardDeadPortIsSilent(t *testing.T) {
+	// Port 1 is not listening; forward must return promptly without panic.
+	forward([]byte(`{}`), "1", "7")
+}
+
+func TestForwardMissingEnvIsNoop(t *testing.T) {
+	forward([]byte(`{}`), "", "") // no port/sid -> no request, no panic
+}

--- a/docs/superpowers/plans/2026-06-23-statusline-capture.md
+++ b/docs/superpowers/plans/2026-06-23-statusline-capture.md
@@ -1,0 +1,782 @@
+# Statusline Capture (Sub-plan 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture Claude's official cost / context% / model per pane by wrapping the statusline command with a Go forwarder shim that POSTs Claude's statusline JSON back to MTUI, attributed by `MULTITERMINAL_SESSION_ID`.
+
+**Architecture:** A new compiled shim `cmd/statusline-forward` is registered as Claude's `statusLine.command`, wrapping the real statusline (MTUI's PS1 or the user's own). It tees Claude's stdin: pipes it to the wrapped command (display unchanged) and fire-and-forget POSTs a copy to a new localhost `/api/statusline` endpoint. The handler writes the official cost/context/model onto the `Session` and marks `costSource=statusline` so the screen-scrape can't clobber it. The pipeline `active→done` edge is untouched.
+
+**Tech Stack:** Go 1.26 (stdlib `net/http`, `os/exec`), Wails v3 events, existing localhost tmux-API server pattern.
+
+## Global Constraints
+
+- **Platform:** Windows (primary). CLI/statusline invoked through `cmd.exe`/`powershell`.
+- **Max 300 lines per Go file.** Split by responsibility.
+- **Never block or allocate under `Session.mu`.** Read/parse outside the lock; lock only for field assignment.
+- **The pipeline `active→done` edge must stay byte-identical.** It is driven by `DetectActivity`/`HasHookData` in `app_scan.go`; `processQueue`/`notifyOrchestratorDone` fire only on a fresh `done` transition and read `prevActivity`, never token state. Cost updates must not change this.
+- **Forwarder is fire-and-forget and failure-silent.** A down/stale MTUI must never break or delay Claude's statusline display.
+- **Structs that cross a Wails binding return need `json`+`yaml` tags and manual `models.ts` sync. Event payloads do NOT.** `terminal:activity` is an event — no `models.ts` change.
+
+---
+
+### Task 1: `statusline-forward` shim — passthrough + best-effort POST
+
+**Files:**
+- Create: `cmd/statusline-forward/main.go`
+- Test: `cmd/statusline-forward/main_test.go`
+
+**Interfaces:**
+- Produces: a binary `statusline-forward(.exe)`. Invoked as `statusline-forward <wrapped-cmd> [args...]`; reads Claude's statusline JSON on stdin; relays the wrapped command's stdout/exit; POSTs `{"sessionId":<int>,"payload":<raw json>}` to `http://127.0.0.1:$MTUI_PORT/api/statusline`.
+- Internal testable funcs: `runWrapped(args []string, stdin []byte, stdout, stderr io.Writer) int` and `forward(payload []byte, port, sid string)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// cmd/statusline-forward/main_test.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunWrappedPassesThroughStdoutAndExit(t *testing.T) {
+	var out bytes.Buffer
+	// `cmd /c echo hi` prints "hi"; exit 0.
+	code := runWrapped([]string{"cmd", "/c", "echo", "hi"}, []byte("{}"), &out, io.Discard)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "hi") {
+		t.Fatalf("stdout = %q, want it to contain %q", out.String(), "hi")
+	}
+}
+
+func TestRunWrappedNoArgsIsNoop(t *testing.T) {
+	var out bytes.Buffer
+	if code := runWrapped(nil, []byte("{}"), &out, io.Discard); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+}
+
+func TestForwardPostsSessionIdAndPayload(t *testing.T) {
+	type got struct {
+		SessionID int             `json:"sessionId"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	ch := make(chan got, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var g got
+		_ = json.NewDecoder(r.Body).Decode(&g)
+		ch <- g
+	}))
+	defer srv.Close()
+	port := strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+
+	forward([]byte(`{"cost":{"total_cost_usd":0.42}}`), port, "7")
+
+	select {
+	case g := <-ch:
+		if g.SessionID != 7 {
+			t.Fatalf("sessionId = %d, want 7", g.SessionID)
+		}
+		if !strings.Contains(string(g.Payload), "0.42") {
+			t.Fatalf("payload = %s, want it to contain 0.42", g.Payload)
+		}
+	default:
+		t.Fatal("server received no request")
+	}
+}
+
+func TestForwardDeadPortIsSilent(t *testing.T) {
+	// Port 1 is not listening; forward must return promptly without panic.
+	forward([]byte(`{}`), "1", "7")
+}
+
+func TestForwardMissingEnvIsNoop(t *testing.T) {
+	forward([]byte(`{}`), "", "")   // no port/sid -> no request, no panic
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/statusline-forward/...`
+Expected: FAIL — `undefined: runWrapped`, `undefined: forward`.
+
+- [ ] **Step 3: Write the implementation**
+
+```go
+// cmd/statusline-forward/main.go
+// Command statusline-forward wraps a Claude Code statusLine command: it relays
+// the wrapped command's output (so the displayed status line is unchanged) and
+// fire-and-forget POSTs Claude's statusline JSON to MTUI for telemetry capture.
+// It must never block or break the wrapped statusline.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+func main() {
+	data, _ := io.ReadAll(os.Stdin)
+	// Display first: relay the wrapped statusline so the POST never delays it.
+	code := runWrapped(os.Args[1:], data, os.Stdout, os.Stderr)
+	// Then capture, best-effort.
+	forward(data, os.Getenv("MTUI_PORT"), os.Getenv("MULTITERMINAL_SESSION_ID"))
+	os.Exit(code)
+}
+
+// runWrapped runs args[0] with args[1:], feeding stdin and relaying stdout/stderr.
+// Returns the wrapped process exit code (0 when there is no wrapped command).
+func runWrapped(args []string, stdin []byte, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return 0
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = bytes.NewReader(stdin)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return ee.ExitCode()
+		}
+		return 1
+	}
+	return 0
+}
+
+// forward POSTs the raw statusline JSON to MTUI. Silent on any failure.
+func forward(payload []byte, port, sid string) {
+	if port == "" || sid == "" {
+		return
+	}
+	id, err := strconv.Atoi(sid)
+	if err != nil {
+		return
+	}
+	body, err := json.Marshal(struct {
+		SessionID int             `json:"sessionId"`
+		Payload   json.RawMessage `json:"payload"`
+	}{SessionID: id, Payload: json.RawMessage(payload)})
+	if err != nil {
+		return
+	}
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Post("http://127.0.0.1:"+port+"/api/statusline",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/statusline-forward/...`
+Expected: PASS (all 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/statusline-forward/
+git commit -m "feat(statusline): add statusline-forward shim (passthrough + best-effort POST)"
+```
+
+---
+
+### Task 2: Session statusline fields, setter/getters, and ScanTokens gate
+
+**Files:**
+- Modify: `internal/terminal/session.go` (add fields to the `Session` struct, ~line 62-66)
+- Create: `internal/terminal/session_statusline.go`
+- Modify: `internal/terminal/activity.go` (gate the cost write in `ScanTokens`, ~line 46-54)
+- Test: `internal/terminal/session_statusline_test.go`
+
+**Interfaces:**
+- Consumes: `Session.mu`, `Session.Tokens TokenInfo` (`{TotalCost, InputTokens, OutputTokens}`), `Session.Screen.Write([]byte)`.
+- Produces:
+  - `type CostSource int; const (CostSourceScrape CostSource = iota; CostSourceStatusline)`
+  - `func (s *Session) SetStatuslineData(cost float64, contextPct int, model string)`
+  - `func (s *Session) StatuslineInfo() (contextPct int, model string, src CostSource)`
+
+- [ ] **Step 1: Add the fields to the Session struct**
+
+In `internal/terminal/session.go`, inside `type Session struct`, after the `Tokens TokenInfo` field (line 62):
+
+```go
+	// Statusline-sourced telemetry (Claude's statusLine JSON via the forwarder shim).
+	// When costSource == CostSourceStatusline, the screen scrape must not overwrite cost.
+	statuslineCost float64
+	contextPct     int
+	model          string
+	costSource     CostSource
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```go
+// internal/terminal/session_statusline_test.go
+package terminal
+
+import "testing"
+
+func TestSetStatuslineDataSetsFieldsAndSource(t *testing.T) {
+	s := NewSession(1, 24, 80)
+	s.SetStatuslineData(0.42, 35, "claude-opus-4-8")
+
+	if got := s.GetTokens().TotalCost; got != 0.42 {
+		t.Fatalf("TotalCost = %v, want 0.42", got)
+	}
+	pct, model, src := s.StatuslineInfo()
+	if pct != 35 || model != "claude-opus-4-8" || src != CostSourceStatusline {
+		t.Fatalf("StatuslineInfo() = (%d,%q,%d), want (35,claude-opus-4-8,statusline)", pct, model, src)
+	}
+}
+
+func TestScanTokensDoesNotOverwriteStatuslineCost(t *testing.T) {
+	s := NewSession(1, 24, 80)
+	s.SetStatuslineData(0.42, 0, "")
+	// Put a different cost on screen; the scrape must NOT win.
+	_, _ = s.Screen.Write([]byte("context left: $0.99\r\n"))
+
+	s.ScanTokens()
+
+	if got := s.GetTokens().TotalCost; got != 0.42 {
+		t.Fatalf("TotalCost = %v after ScanTokens, want 0.42 (statusline authoritative)", got)
+	}
+}
+
+func TestScanTokensStillScrapesWhenNoStatusline(t *testing.T) {
+	s := NewSession(1, 24, 80)
+	_, _ = s.Screen.Write([]byte("cost: $0.99\r\n"))
+
+	s.ScanTokens()
+
+	if got := s.GetTokens().TotalCost; got != 0.99 {
+		t.Fatalf("TotalCost = %v, want 0.99 (scrape active)", got)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/terminal/ -run 'Statusline|ScanTokens' -v`
+Expected: FAIL — `undefined: SetStatuslineData`, `undefined: CostSourceStatusline`.
+
+- [ ] **Step 4: Write the setter/getters**
+
+```go
+// internal/terminal/session_statusline.go
+package terminal
+
+// CostSource records which source last set the session's cost, so the screen
+// scrape (ScanTokens) does not clobber an authoritative statusline value.
+type CostSource int
+
+const (
+	CostSourceScrape     CostSource = iota // cost derived from screen scraping
+	CostSourceStatusline                   // cost from Claude's statusLine JSON
+)
+
+// SetStatuslineData records official cost/context/model from Claude's statusLine
+// and marks the statusline as the authoritative cost source. Called from the
+// /api/statusline HTTP handler; assignment only, no I/O under the lock.
+func (s *Session) SetStatuslineData(cost float64, contextPct int, model string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuslineCost = cost
+	s.contextPct = contextPct
+	s.model = model
+	s.costSource = CostSourceStatusline
+	s.Tokens.TotalCost = cost // single displayed cost field stays authoritative
+}
+
+// StatuslineInfo returns the statusline-sourced context%/model and the current
+// cost source.
+func (s *Session) StatuslineInfo() (contextPct int, model string, src CostSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.contextPct, s.model, s.costSource
+}
+```
+
+- [ ] **Step 5: Gate the cost scrape in ScanTokens**
+
+In `internal/terminal/activity.go`, replace the cost-match block (currently ~lines 49-54, after `s.mu.Lock()`):
+
+```go
+	// Look for cost patterns like $0.12 or $1.50 — but never overwrite an
+	// authoritative statusline-sourced cost.
+	if s.costSource != CostSourceStatusline {
+		if matches := costPattern.FindStringSubmatch(content); len(matches) >= 2 {
+			if v, err := strconv.ParseFloat(matches[1], 64); err == nil {
+				s.Tokens.TotalCost = v
+			}
+		}
+	}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/terminal/ -run 'Statusline|ScanTokens' -v`
+Expected: PASS (3).
+
+- [ ] **Step 7: Run the full terminal package under race**
+
+Run: `go test -race ./internal/terminal/...`
+Expected: PASS, no race warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/terminal/session.go internal/terminal/session_statusline.go internal/terminal/activity.go internal/terminal/session_statusline_test.go
+git commit -m "feat(statusline): Session cost source + statusline data, gate scrape"
+```
+
+---
+
+### Task 3: `/api/statusline` endpoint and handler
+
+**Files:**
+- Modify: `internal/backend/app_tmux_api.go` (register one route in `startTmuxAPI`, line 22)
+- Create: `internal/backend/app_statusline_api.go` (payload type + handler)
+- Test: `internal/backend/app_statusline_api_test.go`
+
+**Interfaces:**
+- Consumes: `a.mu`, `a.sessions map[int]*terminal.Session` (lookup pattern from `app.go:242`), `Session.SetStatuslineData(cost, contextPct, model)`.
+- Produces: `POST /api/statusline` accepting `{"sessionId":int,"payload":<claude statusline json>}`; calls `SetStatuslineData`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/backend/app_statusline_api_test.go
+package backend
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
+)
+
+func TestHandleStatuslineUpdatesSession(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	sess := terminal.NewSession(5, 24, 80)
+	a.sessions[5] = sess
+
+	body := `{"sessionId":5,"payload":{"cost":{"total_cost_usd":1.23},` +
+		`"context_window":{"used_percentage":40},"model":{"display_name":"Opus 4.8"}}}`
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	a.handleStatusline(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := sess.GetTokens().TotalCost; got != 1.23 {
+		t.Fatalf("TotalCost = %v, want 1.23", got)
+	}
+	pct, model, src := sess.StatuslineInfo()
+	if pct != 40 || model != "Opus 4.8" || src != terminal.CostSourceStatusline {
+		t.Fatalf("StatuslineInfo = (%d,%q,%d), want (40,Opus 4.8,statusline)", pct, model, src)
+	}
+}
+
+func TestHandleStatuslineUnknownSessionNoCrash(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(`{"sessionId":99,"payload":{}}`))
+	rec := httptest.NewRecorder()
+	a.handleStatusline(rec, req) // must not panic
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandleStatuslineGarbageBodyIsBadRequest(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(`not json`))
+	rec := httptest.NewRecorder()
+	a.handleStatusline(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/backend/ -run Statusline -v`
+Expected: FAIL — `a.handleStatusline undefined`.
+
+- [ ] **Step 3: Write the handler**
+
+```go
+// internal/backend/app_statusline_api.go
+package backend
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// statuslinePayload is MTUI's wrapper around Claude's raw statusLine JSON,
+// posted by the statusline-forward shim. Only the fields MTUI consumes are typed;
+// unknown fields are ignored.
+type statuslinePayload struct {
+	SessionID int `json:"sessionId"`
+	Payload   struct {
+		Cost struct {
+			TotalCostUSD  float64 `json:"total_cost_usd"`
+			TotalDuration int     `json:"total_duration_ms"`
+		} `json:"cost"`
+		ContextWindow struct {
+			UsedPercentage float64 `json:"used_percentage"`
+		} `json:"context_window"`
+		Model struct {
+			DisplayName string `json:"display_name"`
+		} `json:"model"`
+	} `json:"payload"`
+}
+
+// handleStatusline records cost/context/model from a forwarded statusLine update.
+// Loopback-only, POST-only, no auth (same trust model as /api/tmux/log).
+func (a *AppService) handleStatusline(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	var p statuslinePayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	a.mu.Lock()
+	sess := a.sessions[p.SessionID]
+	a.mu.Unlock()
+	if sess != nil {
+		sess.SetStatuslineData(
+			p.Payload.Cost.TotalCostUSD,
+			int(p.Payload.ContextWindow.UsedPercentage),
+			p.Payload.Model.DisplayName,
+		)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+```
+
+- [ ] **Step 4: Register the route**
+
+In `internal/backend/app_tmux_api.go`, `startTmuxAPI`, after line 22 (`mux.HandleFunc("/api/tmux/log", a.handleTmuxLog)`):
+
+```go
+	mux.HandleFunc("/api/statusline", a.handleStatusline)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/backend/ -run Statusline -v`
+Expected: PASS (3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/backend/app_statusline_api.go internal/backend/app_tmux_api.go internal/backend/app_statusline_api_test.go
+git commit -m "feat(statusline): /api/statusline endpoint records cost/context/model"
+```
+
+---
+
+### Task 4: Wrap the statusline command with the forwarder
+
+**Files:**
+- Modify: `internal/backend/app_statusline.go` (`applyStatusLine`, lines 81-83 — build the wrapping command)
+- Create: `internal/backend/app_statusline_wrap.go` (forwarder-path resolution + command builder)
+- Test: `internal/backend/app_statusline_wrap_test.go`
+
+**Interfaces:**
+- Consumes: `GetStatusLineStatus()` → `{HasExisting bool, IsOurs bool, ExistingCommand string}`; `statusLineScriptPath()`.
+- Produces: `func statuslineForwardPath() string` (the shim next to the running exe); `func wrapStatuslineCommand(forwarder, inner string) string` (the `statusLine.command` string).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/backend/app_statusline_wrap_test.go
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWrapStatuslineCommandPrependsForwarder(t *testing.T) {
+	inner := `powershell -NonInteractive -NoProfile -File "C:/Users/x/.claude/mtui-statusline.ps1"`
+	got := wrapStatuslineCommand(`C:/Users/x/AppData/.../statusline-forward.exe`, inner)
+
+	if !strings.HasPrefix(got, `"C:/Users/x/AppData/.../statusline-forward.exe" `) {
+		t.Fatalf("command = %q, want it to start with the quoted forwarder path", got)
+	}
+	if !strings.HasSuffix(got, inner) {
+		t.Fatalf("command = %q, want it to end with the wrapped inner command %q", got, inner)
+	}
+}
+
+func TestWrapStatuslineCommandEmptyForwarderReturnsInner(t *testing.T) {
+	// Fail-safe: no forwarder available -> register the inner command unchanged.
+	inner := `powershell -File foo.ps1`
+	if got := wrapStatuslineCommand("", inner); got != inner {
+		t.Fatalf("command = %q, want unchanged inner %q", got, inner)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/backend/ -run WrapStatusline -v`
+Expected: FAIL — `wrapStatuslineCommand undefined`.
+
+- [ ] **Step 3: Write the wrapper helpers**
+
+```go
+// internal/backend/app_statusline_wrap.go
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// statuslineForwardPath returns the path to the statusline-forward shim, which
+// is built alongside the main binary in the same directory. Returns "" if it
+// cannot be located, in which case the statusline is registered unwrapped.
+func statuslineForwardPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	name := "statusline-forward"
+	if filepath.Ext(exe) == ".exe" {
+		name += ".exe"
+	}
+	p := filepath.Join(filepath.Dir(exe), name)
+	if _, err := os.Stat(p); err != nil {
+		return ""
+	}
+	return filepath.ToSlash(p)
+}
+
+// wrapStatuslineCommand builds the statusLine.command string: the quoted
+// forwarder followed by the inner (real) statusline command it wraps. If
+// forwarder is "", the inner command is returned unchanged (fail-safe).
+func wrapStatuslineCommand(forwarder, inner string) string {
+	if forwarder == "" {
+		return inner
+	}
+	return `"` + forwarder + `" ` + inner
+}
+```
+
+- [ ] **Step 4: Use the wrapper in applyStatusLine**
+
+In `internal/backend/app_statusline.go`, replace lines 81-83:
+
+```go
+	// Use forward slashes so PowerShell resolves the path correctly on Windows.
+	fwdPath := strings.ReplaceAll(scriptPath, `\`, `/`)
+	command := `powershell -NonInteractive -NoProfile -File "` + fwdPath + `"`
+```
+
+with:
+
+```go
+	// Use forward slashes so PowerShell resolves the path correctly on Windows.
+	fwdPath := strings.ReplaceAll(scriptPath, `\`, `/`)
+	inner := `powershell -NonInteractive -NoProfile -File "` + fwdPath + `"`
+	// Wrap with the forwarder shim so MTUI captures Claude's statusline telemetry.
+	// If the user already has a statusline, wrap THAT instead so capture still works.
+	if st := a.GetStatusLineStatus(); st.HasExisting && !st.IsOurs && st.ExistingCommand != "" {
+		inner = st.ExistingCommand
+	}
+	command := wrapStatuslineCommand(statuslineForwardPath(), inner)
+```
+
+- [ ] **Step 5: Run tests + build to verify**
+
+Run: `go test ./internal/backend/ -run 'WrapStatusline|Statusline' -v && go build ./...`
+Expected: PASS; build succeeds.
+
+- [ ] **Step 6: Add the shim to the build pipeline**
+
+In `Taskfile.yml`, in the `build` task, add a step to compile the shim into the same output dir as the main binary (next to `mtui-portable.exe` / `multiterminal.exe`):
+
+```yaml
+      - go build -o build/bin/statusline-forward.exe ./cmd/statusline-forward
+```
+
+Place it immediately after the main `go build` step so both land in `build/bin/`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/backend/app_statusline.go internal/backend/app_statusline_wrap.go internal/backend/app_statusline_wrap_test.go Taskfile.yml
+git commit -m "feat(statusline): wrap statusline command with forwarder shim"
+```
+
+---
+
+### Task 5: Emit context% and model on the activity event
+
+**Files:**
+- Modify: `internal/backend/app_scan.go` (`ActivityInfo` struct lines 14-19; `scanAllSessions` emit ~lines 125-154)
+- Test: `internal/backend/app_scan_test.go` (add a focused test; create the file if absent)
+
+**Interfaces:**
+- Consumes: `Session.StatuslineInfo() (int, string, CostSource)`, existing `GetTokens()`.
+- Produces: `ActivityInfo` gains `ContextPct int` and `Model string`; emitted on the existing `terminal:activity` event (no `models.ts` change — it is an event payload, consumed via `EventsOn` in `App.svelte`).
+
+- [ ] **Step 1: Extend the ActivityInfo struct**
+
+In `internal/backend/app_scan.go`, lines 14-19:
+
+```go
+// ActivityInfo is sent to the frontend when a session's activity state changes.
+type ActivityInfo struct {
+	ID         int    `json:"id"`
+	Activity   string `json:"activity"` // "idle", "active", "done", "waitingPermission", "waitingAnswer", "error"
+	Cost       string `json:"cost"`
+	Title      string `json:"title"`      // OSC-derived window title (fallback pane name)
+	ContextPct int    `json:"contextPct"` // % of context window used (statusline); 0 if unknown
+	Model      string `json:"model"`      // model display name (statusline); "" if unknown
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```go
+// internal/backend/app_scan_test.go
+package backend
+
+import "testing"
+
+func TestActivityInfoCarriesStatuslineFields(t *testing.T) {
+	// Guards that the event payload exposes context%/model so the frontend can render them.
+	info := ActivityInfo{ID: 1, Activity: "active", Cost: "$1.23", ContextPct: 40, Model: "Opus 4.8"}
+	if info.ContextPct != 40 || info.Model != "Opus 4.8" {
+		t.Fatalf("ActivityInfo = %+v, want ContextPct=40 Model=Opus 4.8", info)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/backend/ -run ActivityInfoCarries -v`
+Expected: FAIL — `unknown field ContextPct` (until Step 1 is saved) → after Step 1, this test passes; its purpose is to lock the field names. If Step 1 is already saved, confirm it PASSES and proceed.
+
+- [ ] **Step 4: Populate the fields in scanAllSessions**
+
+In `internal/backend/app_scan.go`, in `scanAllSessions`, after `tokens := sess.GetTokens()` (line 125) add:
+
+```go
+		ctxPct, model, _ := sess.StatuslineInfo()
+```
+
+Then extend the emitted struct in the `a.app.Event.Emit("terminal:activity", ...)` call (lines 148-153) to include the new fields:
+
+```go
+			a.app.Event.Emit("terminal:activity", ActivityInfo{
+				ID:         id,
+				Activity:   actStr,
+				Cost:       costStr,
+				Title:      title,
+				ContextPct: ctxPct,
+				Model:      model,
+			})
+```
+
+- [ ] **Step 5: Run the backend tests + done-edge regression guard**
+
+Run: `go test ./internal/backend/...`
+Expected: PASS. In particular, the existing queue/scan tests that assert `processQueue` fires on the `done` transition must still pass — confirm none regressed (the cost/context/model additions do not touch `activityChanged`/`actStr` logic).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/backend/app_scan.go internal/backend/app_scan_test.go
+git commit -m "feat(statusline): emit context% and model on terminal:activity"
+```
+
+---
+
+### Task 6: End-to-end verification gate (runtime, manual)
+
+**Files:** none (verification only). This task gates the branch; it produces a short verification note, not code.
+
+**Why:** The forwarder's value rests on two things that unit tests cannot prove: (a) the env vars `MULTITERMINAL_SESSION_ID`/`MTUI_PORT` actually reach the statusline child through the PTY → `cmd.exe /c claude` → statusline chain; (b) Claude invokes the wrapped command correctly (quoting survives) and the display is unchanged.
+
+- [ ] **Step 1: Build and run**
+
+Run:
+```bash
+cd frontend && npm run build && cd ..
+go build -o build/bin/multiterminal.exe -tags desktop .
+go build -o build/bin/statusline-forward.exe ./cmd/statusline-forward
+build/bin/multiterminal.exe
+```
+
+- [ ] **Step 2: Verify capture end-to-end**
+
+In the running app, open a Claude (yolo) pane in a real git repo and send one prompt so an assistant turn completes (triggers a statusline render). Then confirm in the app log that `/api/statusline` was hit and the pane's cost/model updated:
+
+Expected: a log line from the handler (add a `log.Printf("[statusline] session %d cost=%.4f model=%q", ...)` temporarily if needed) AND the pane footer/title shows a non-`$0.00` cost and the model name. The statusline at the bottom of the Claude TUI must still render normally (wrap is transparent).
+
+- [ ] **Step 3: Verify failure-silence**
+
+Stop the app's API (or note that on the next app restart the port changes); confirm a still-running Claude pane's statusline keeps rendering with no hang/stall, and the pane simply stops updating cost (no crash, no error dialog).
+
+- [ ] **Step 4: Record the result**
+
+Append a short "E2E verified on <date>: capture works, wrap transparent, fail-silent confirmed" note to the PR description. If quoting broke the wrapped invocation (statusline blank or error), fix `wrapStatuslineCommand`/`applyStatusLine` quoting and re-verify before merge.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(statusline): e2e quoting/inheritance fixes from runtime verification"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Rev 4 Sub-plan 1):**
+- Go forwarder shim, tee + best-effort POST → Task 1. ✓
+- Wrap existing statusline (D7) → Task 4. ✓
+- `/api/statusline` endpoint, session lookup → Task 3. ✓
+- `Session.SetStatuslineData` + new fields + `costSource` gate on `ScanTokens` → Task 2. ✓
+- Event (not binding) for context%/model; no `models.ts` change → Task 5. ✓
+- `done`-edge untouched (regression guard) → Task 5 Step 5. ✓
+- Blocker: end-to-end env inheritance + non-blocking-under-cancellation → Task 6. ✓
+- Build pipeline ships the shim next to the exe → Task 4 Step 6. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; every command has expected output. ✓
+
+**Type consistency:** `SetStatuslineData(cost float64, contextPct int, model string)`, `StatuslineInfo() (int, string, CostSource)`, `CostSourceStatusline`, `statuslinePayload`, `wrapStatuslineCommand(forwarder, inner string) string`, `statuslineForwardPath() string`, `ActivityInfo.ContextPct/.Model` — used identically across Tasks 2–5. ✓
+
+**Note on Task 5 Step 3:** the `ActivityInfoCarries` test only compiles after the struct change in Step 1; treat Step 1+2 as written together (the test locks the field names). This is intentional, not a placeholder.

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -1,0 +1,182 @@
+# claudelog — JSONL Session Reader (Foundation)
+
+- **Date:** 2026-06-23
+- **Status:** Approved design, pre-implementation
+- **Branch target:** `alpha-main` (feature branch off it)
+- **Scope:** Foundation only. Replaces fragile screen-scraping of Claude token/cost data with a structured reader of Claude Code's JSONL session logs, and adds a turn-state–based "working" signal plus a convergence ("stuck loop") warning. Subagents and todos are parsed but not yet rendered (explicit follow-on).
+
+## Context
+
+MTUI currently derives Claude token/cost/activity data by scraping the **rendered terminal screen** (`internal/terminal/activity.go`):
+
+- `ScanTokens()` matches `$\d+\.\d+` for cost and `"15.2k input"` / `"3.8k output"` regexes — only two token counters, no cache tokens, dependent on whatever Claude happens to print (theme, width, CLI version).
+- `DetectActivity()` / `classifyScreenState()` classify activity from prompt/question heuristics over the last 15 screen rows.
+
+This is inaccurate and version-fragile. Claude Code already writes complete, structured data to disk under `~/.claude/projects/{encoded_path}/{sessionId}.jsonl`. Reading it directly yields exact tokens (four counters), per-model cost, subagent state, todos, and a precise turn-state.
+
+**MTUI's structural advantage over external monitors (e.g. Agent-Dashboard):** MTUI owns the PTY. It knows each session's working directory (`session.Dir`), its start time, and often its session id (`hookSessionID`, set by Claude Code hooks via `HasHookData()`). So JSONL-file resolution is direct, not a `ps`/`lsof` guess. The whole external process-discovery layer that makes Agent-Dashboard Unix-only is unnecessary here — this design is Windows-native by construction.
+
+### The Windows path-encoding finding
+
+Claude encodes the absolute project path into the project directory name by replacing path separators and punctuation with `-`. On Windows this includes the drive colon and backslash, which a Unix-only encoder (like Agent-Dashboard's, which only replaces `/`, `.`, `_`) does not handle. Verified on the target machine:
+
+```
+D:\repos\Multiterminal  →  ~/.claude/projects/D--repos-Multiterminal/
+```
+
+So the encoder must replace **`:`, `\`, `/`, `.`, `_` → `-`**. The logs for this very project already exist on disk, so the approach is validated on Windows.
+
+## Goals
+
+1. Exact Claude token usage (input / output / cache-creation / cache-read) and computed API-equivalent cost per pane, replacing the regex scrape when JSONL is resolvable.
+2. A distinct **working** (generating now) vs. **owes-you** (waiting on user) signal derived from conversation turn-state.
+3. A **convergence** warning flag when the agent repeats the same tool 5× in a row (stuck loop).
+4. Zero regression: non-Claude panes and unresolvable Claude sessions keep today's screen-scraping behavior via a soft fallback.
+
+## Non-Goals (deferred follow-ons)
+
+- Rendering subagents and todos in the UI (they are parsed into `SessionData` and shipped on the activity event, but UI visualization is a separate plan).
+- `linesAdded` / `filesModified` / `gitCommits` / `toolErrors` extraction (cheap to add to the same parse pass later; no foundation value).
+- A real-time fsnotify watcher subsystem (Approach C). Polling within the existing scan loop is the foundation; the package API must not preclude a later watcher.
+- Multi-provider (Codex/Gemini) JSONL parsing.
+
+## Architecture
+
+New leaf package **`internal/terminal/claudelog`** — depends only on the standard library, no backend imports, independently testable. Max 300 lines per file (project rule).
+
+| File | Responsibility |
+|---|---|
+| `encode.go` | Windows-aware path encoder + JSONL session-file resolution |
+| `parse.go` | JSONL line parsing: token sum, turn-state, tool tracking, subagents, todos |
+| `pricing.go` | `MODEL_PRICING` table + cost computation |
+| `types.go` | `SessionData` and nested result types |
+| `*_test.go` | per-file table tests + `testdata/*.jsonl` fixtures |
+
+### Data model (`types.go`)
+
+```go
+type TokenUsage struct {
+    InputTokens         int
+    OutputTokens        int
+    CacheCreationTokens int
+    CacheReadTokens     int
+}
+
+type PendingTool struct {
+    ID      string
+    Tool    string
+    Pattern string // command or file path the agent is blocked on
+}
+
+type SubAgent struct {
+    ID              string
+    Type            string
+    Status          string
+    CurrentAction   string
+    TokensUsed      int
+    DurationSeconds int
+}
+
+type Todo struct {
+    Subject string
+    Status  string // pending | in_progress | completed
+}
+
+type SessionData struct {
+    SessionID       string
+    Model           string
+    Tokens          TokenUsage
+    CostUSD         float64
+    TurnOpen        bool          // agent owes the next step
+    PendingTool     *PendingTool  // last tool_use without a matching tool_result
+    Convergence     bool          // last 5 tool calls identical
+    ConvergenceTool string
+    Subagents       []SubAgent
+    Todos           []Todo
+    UpdatedAt       time.Time
+}
+```
+
+## Components
+
+### 1. Encoder + resolver (`encode.go`)
+
+```go
+func EncodePath(absPath string) string            // replace : \ / . _ → -
+func ConfigDir(ptyEnv []string) string            // CLAUDE_CONFIG_DIR or ~/.claude
+func ResolveSessionFile(configDir, cwd, hookSessionID string, startedAt time.Time) (string, bool)
+```
+
+Resolution order:
+
+1. Project dir = `{configDir}/projects/{EncodePath(cwd)}`.
+2. If `hookSessionID != ""` → `{projDir}/{hookSessionID}.jsonl` (if it exists).
+3. Else → list `{projDir}/*.jsonl`, pick the file with newest mtime where `mtime >= startedAt`. MTUI's known PTY start time disambiguates multiple sessions sharing one cwd.
+4. cwd empty or `/` → no file (skip).
+
+### 2. Parser (`parse.go`)
+
+Two-tier read (pattern proven by Agent-Dashboard's parser):
+
+- **Tail read — last 32 KB** for live state: pair `tool_use`↔`tool_result`, record the trailing entry type, the last N tool names, subagent references, todos (from `TodoWrite` tool inputs), and the model.
+  - `TurnOpen = (lastEntryType == "user") || (PendingTool != nil)`.
+  - `PendingTool` = the most recent `tool_use` with no matching `tool_result`.
+  - `Convergence` = the last 5 recorded tool names are all identical → set flag + `ConvergenceTool`.
+- **Full-file token sum** for authoritative totals: byte-level prefilter (only unmarshal lines containing `"usage"` or `"compact_boundary"`), sum every assistant message's per-message usage across the whole file (compaction-safe). The 32 KB tail cannot be trusted for totals on long/compacted sessions.
+
+Robustness: the JSONL schema is undocumented and version-dependent. Tolerate unknown fields; on any parse error, return `(nil, false)` so the caller falls back to screen-scraping. Never panic, never emit zeroed-out data that would overwrite good screen-scrape values.
+
+### 3. Pricing (`pricing.go`)
+
+```go
+var MODEL_PRICING = map[string]Pricing{ /* per-1M-token rates incl. cache tiers */ }
+func CostUSD(model string, t TokenUsage) float64
+```
+
+Cost is **API-equivalent estimate**, not actual billing for Pro/Max plans — surfaced as such in the UI.
+
+### 4. Caching
+
+Cache the resolved file path + file identity (size, mtime) keyed by **MTUI session ID**. The expensive full-file token scan runs only on a cache miss (file changed). TTL ≈ the scan interval. The package API must remain pure (`Read(args) → SessionData`) so a later fsnotify watcher can replace polling without changing callers.
+
+## Data flow (scan-loop integration)
+
+In `scanAllSessions` (`internal/backend/app_scan.go`), for Claude panes:
+
+1. `data, ok := claudelog.Read(session)`.
+2. **Tokens/cost:** if `ok` → set `s.Tokens` from `data` (four counters) and cost from `data.CostUSD`. Else → keep today's `ScanTokens()` regex as fallback.
+3. **Activity — additive priority, existing logic preserved:**
+   1. **Hooks** (`HasHookData()`) — unchanged, highest authority (permission/stop).
+   2. **JSONL turn-state** — *new*: provides the fine **working** (generating) vs. **owes-you** (waiting on user) distinction. Fused with PTY liveness: recent PTY output (existing `LastOutputAt` < ~1.5 s gate) → generating; turn closed + quiesced → done/waiting.
+   3. **Screen-scrape** (`DetectActivity`) — fallback for non-Claude / unresolved sessions.
+4. **Convergence** is a separate warning flag (not an `ActivityState`) surfaced as a badge.
+
+### Struct & binding changes
+
+- Extend `terminal.TokenInfo` with `CacheCreationTokens`, `CacheReadTokens`.
+- Extend the `ActivityInfo` event payload with `working bool` and `convergence bool` (and ship parsed subagents/todos for the follow-on UI).
+- **Mandatory (per CLAUDE.md & memory — recurring silent-strip bug):** manually mirror every new field into `frontend/wailsjs/go/models.ts` (class field declaration + constructor assignment). Tracked as its own plan step.
+
+## Testing
+
+- **Encoder:** table tests with Windows paths (`D:\repos\…`, `C:\Users\…`), a worktree path, empty cwd.
+- **Resolver:** hook-id path vs. newest-file path; two sessions in one cwd disambiguated by `startedAt`; missing project dir.
+- **Parser:** token sum across a compaction boundary; turn-state open/closed; pending tool; convergence (5 identical / not); subagents; todos. Own `testdata/*.jsonl` fixtures.
+- **Pricing:** per-model incl. cache tiers; unknown model → 0 (no crash).
+- **Integration:** a fake `~/.claude/projects/…` tree + a fake `Session` with `Dir` set → assert `SessionData`.
+- **Fallback:** corrupt/truncated JSONL → `(nil, false)`, no crash, screen-scrape still drives state.
+- `go test ./internal/terminal/...` green under the race detector.
+
+## Risks
+
+- **Schema drift:** Claude's JSONL format may change between versions → isolated parsing, tolerant unmarshal, soft fallback.
+- **Cost accuracy:** estimate only, not real Pro/Max billing → label in UI.
+- **Performance:** full-file scan on large sessions → mitigated by the size/mtime cache and byte-level prefilter; full scan runs only on change.
+- **Config override:** `CLAUDE_CONFIG_DIR` must be read from the PTY environment, not assumed to be `~/.claude`.
+
+## Follow-ons (out of scope here)
+
+1. Subagent + todo visualization in the pane / future Kanban card.
+2. `linesAdded` / `filesModified` / `gitCommits` / `toolErrors` extraction (same parse pass).
+3. fsnotify watcher subsystem for append-time updates (Approach C).
+4. Multi-provider (Codex/Gemini) session resolution.

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -14,7 +14,7 @@ MTUI currently derives Claude token/cost/activity data by scraping the **rendere
 
 This is inaccurate and version-fragile. Claude Code already writes complete, structured data to disk under `~/.claude/projects/{encoded_path}/{sessionId}.jsonl`. Reading it directly yields exact tokens (four counters), per-model cost, subagent state, todos, and a precise turn-state.
 
-**MTUI's structural advantage over external monitors (e.g. Agent-Dashboard):** MTUI owns the PTY. It knows each session's working directory (`session.Dir`), its start time, and often its session id (`hookSessionID`, set by Claude Code hooks via `HasHookData()`). So JSONL-file resolution is direct, not a `ps`/`lsof` guess. The whole external process-discovery layer that makes Agent-Dashboard Unix-only is unnecessary here — this design is Windows-native by construction.
+**MTUI's structural advantage over external monitors (e.g. Agent-Dashboard):** MTUI owns the PTY. Critically, it **launches Claude with an explicit `--session-id <uuid>` flag** (verified in `CreateSession`: `claude.exe --dangerously-skip-permissions --session-id 4e8cc0b5-…`), so the session id is **deterministically known at launch** — no `ps`/`lsof` discovery, no hook dependency, no newest-file guess. It also knows the working directory (`session.Dir`) and start time. The whole external process-discovery layer that makes Agent-Dashboard Unix-only is unnecessary here — this design is Windows-native by construction.
 
 ### The Windows path-encoding finding
 
@@ -104,15 +104,18 @@ type SessionData struct {
 ```go
 func EncodePath(absPath string) string            // replace : \ / . _ → -
 func ConfigDir(ptyEnv []string) string            // CLAUDE_CONFIG_DIR or ~/.claude
-func ResolveSessionFile(configDir, cwd, hookSessionID string, startedAt time.Time) (string, bool)
+func ResolveSessionFile(configDir, cwd, sessionID, hookSessionID string, startedAt time.Time) (string, bool)
 ```
 
-Resolution order:
+Resolution order (most authoritative first):
 
 1. Project dir = `{configDir}/projects/{EncodePath(cwd)}`.
-2. If `hookSessionID != ""` → `{projDir}/{hookSessionID}.jsonl` (if it exists).
-3. Else → list `{projDir}/*.jsonl`, pick the file with newest mtime where `mtime >= startedAt`. MTUI's known PTY start time disambiguates multiple sessions sharing one cwd.
-4. cwd empty or `/` → no file (skip).
+2. **`sessionID` from the session's own launch argv** (MTUI passes `--session-id <uuid>`) → `{projDir}/{sessionID}.jsonl`. This is the primary, deterministic path.
+3. Fallback `hookSessionID` (if set by hooks and `sessionID` was unavailable) → `{projDir}/{hookSessionID}.jsonl`.
+4. Last-resort fallback → list `{projDir}/*.jsonl`, pick newest mtime where `mtime >= startedAt`. Covers sessions MTUI did not launch with an explicit id (e.g. restored/attached).
+5. cwd empty or `/` → no file (skip).
+
+> Implementation note: the session id must be threaded from the launch argv onto the `Session` struct (parse the `--session-id` value in `Start`, store it). This is a small prerequisite tracked in the implementation plan.
 
 ### 2. Parser (`parse.go`)
 

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -37,7 +37,7 @@ Claude encodes the abs path by replacing **`: \ / . _ ~ → -`** (the `~` is rea
 | D2 | Refresh cadence | **Tail-state** (turn-state, last tools, pending tool) recomputed **every scan tick** from the last ≤64 KB only. **Full token recompute** (whole-file dedup-by-id) at most **every 5 s**, or immediately when the file **shrank** (compaction). No per-read delta summing — full recompute rebuilds the id→usage map from scratch each time. |
 | D3 | Concurrency model | **One goroutine per Claude session** (pane count is capped by `max_panes_per_tab`). **No worker pool** (cut as premature). The scan loop only reads published last-known-good — non-blocking. |
 | D4 | Reader lifecycle owner | A `readerRegistry` owned by `AppService` (its own `sync.Mutex`, not `App.mu`). A reader is created lazily on the first `Latest(session)` for a Claude pane and torn down from the existing `cleanupActivityTracking(id)` site (`app.go:287`). |
-| D5 | "Is a Claude pane" predicate | The session's launch `mode` starts with `"claude"` **and** a non-empty `SessionID` was resolved. `codex`/`gemini` panes are out of scope for the foundation. |
+| D5 | "Is a Claude pane" predicate | **Effective predicate = `SessionID != ""` [R3].** `--session-id` is only ever emitted for claude modes, so a non-empty `SessionID` implies a claude pane. The Go `terminal.Session` has **no `mode` field today** (`mode` is only a `CreateSession` param for env/logging), so the predicate does not depend on one. `codex`/`gemini` out of scope. |
 | D6 | Subagent `Status` | Ship `""` (unknown) in the foundation; derivation deferred to the visualization follow-on. |
 | D7 | Todos | Parse path implemented but `Todos` ships **empty** until a real TodoWrite fixture is captured. |
 | D8 | `CLAUDE_CONFIG_DIR` | Read **once** from the MTUI process env at startup; one config dir process-wide. No per-session override (documented limitation). |
@@ -52,7 +52,7 @@ for each COMPLETE line (terminated by \n):
 total := sum(ids)                   // each id counted once
 ```
 
-**No incremental delta. [R2]** 83 % of ids span >1 physical line (up to 13), so a "sum appended bytes" delta double-counts an id split across refreshes. The byte offset is used **only** for cheap tail-state, never for the token total. The full recompute reads the whole file on D2's cadence.
+**No incremental delta. [R2]** 72 % of ids span >1 physical line (up to 13), so a "sum appended bytes" delta double-counts an id split across refreshes. The byte offset is used **only** for cheap tail-state, never for the token total. The full recompute reads the whole file on D2's cadence.
 
 ### Line framing — the only correct read [R1]
 
@@ -75,7 +75,7 @@ A leaf package `internal/terminal/claudelog`, no backend imports, fully unit-tes
 `ResolveSessionFile` order:
 1. projDir = `{configDir}/projects/{EncodePath(cwd)}`; cwd empty/`/` → `ConfNone`.
 2. `sessionID != ""` and `{projDir}/{sessionID}.jsonl` exists → `ConfHigh`.
-3. else list `{projDir}/*.jsonl`; for each, **scan backward for the last complete line carrying both `cwd` and `gitBranch`** (≤32 lines) and match against the session's dir/branch; among matches require mtime `> startedAt` (ns), newest wins → `ConfLow`; **0 or >1 matches → `ConfNone`** (ambiguous, never guess).
+3. else list `{projDir}/*.jsonl`; for each, **scan backward for the last complete line carrying both `cwd` and `gitBranch`** (≤32 lines; real max observed = 16) and match against the session's dir/branch (exact-string cwd; a deeper cwd such as `…\.worktrees\x\frontend` legitimately won't match → `ConfNone` → scrape). **Disambiguation [R3]:** 54/63 real files in one project share an identical `(cwd, gitBranch)`, so the match set is routinely large — the `mtime > startedAt` gate is the real disambiguator (only the live session's file is written after this session started); among files passing the gate, **newest mtime wins → `ConfLow`**. `ConfNone` only when **zero** files pass the gate **or** ≥2 pass with indistinguishable (sub-second-equal) mtimes — the true 1-second-race tie. Never guess on a tie.
 
 **Tests:** encoder (Windows paths, `PATRIC~1`→`PATRIC-1`, worktree, trailing sep, collisions→ambiguous); resolver (High by id; Low by cwd+gitBranch backward-scan; >1 match→None; missing dir); **token dedup with a multi-block same-`message.id` fixture** (the 2.6× regression guard) + compaction fixture; framing (partial last line ignored, valid prefix returned); turn-state (metadata-trailing must not flip `TurnOpen`; user-trailing open; pending-tool open; assistant-final closed; trailing-assistant-with-tool_use open); convergence; pricing (incl. cache tiers, unknown→0). `go test ./internal/terminal/claudelog/...` green.
 
@@ -98,7 +98,7 @@ Delivers exact, deduped tokens/cost for the **already-id-pinned happy path** (la
 - **Lock discipline [R1]:** read/parse entirely outside any session lock; acquire `s.mu` only for the final assignment; never hold `s.mu` across I/O.
 - **`done` edge untouched [R1/R2]:** the pipeline edge (`app_scan.go:157`) stays driven by `DetectActivity`/`HasHookData`, debounced by the existing 1.5 s gate. Tokens are a separate write the queue never reads.
 
-**Bindings:** extend `terminal.TokenInfo` with the two cache counters; **mirror into `frontend/wailsjs/go/models.ts`** (class field + constructor) — its own step (CLAUDE.md/memory recurring silent-strip bug).
+**Bindings [R3]:** extend `terminal.TokenInfo` with the two cache counters. Note: cost/activity currently reach the frontend as a plain `terminal:activity` **event payload** (`ActivityInfo{Cost string}`), not as a binding-return class — there is **no `TokenInfo`/`ActivityInfo` class in `models.ts` today**, so event payloads may need **no** `models.ts` change. The CLAUDE.md/memory silent-strip rule applies only to structs returned from binding methods; the plan step is "verify whether the new fields cross a binding return (sync `models.ts`) or only an event (no sync needed)", not a blind class edit.
 
 **Tests:** the **scan-loop regression guard** — replay an append-by-append stream and assert `processQueue` fires **exactly once per turn** (never 0, never 2) with tokens changing underneath; **race test** (`-race`) running the reader concurrently with a `readLoop`-style writer to `s.LastOutputAt`, asserting no lock held across I/O; fallback (corrupt complete line / missing file → keep screen-scrape).
 

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -1,198 +1,146 @@
 # claudelog — JSONL Session Reader (Foundation)
 
 - **Date:** 2026-06-23
-- **Status:** Rev 2 — revised after red-team round 1 (empirical findings against real logs)
+- **Status:** Rev 3 — decomposed into 3 sub-plans after red-team rounds 1 & 2 (all findings empirical against real logs)
 - **Branch target:** `alpha-main` (feature branch off it)
-- **Scope:** Foundation only. Replaces fragile screen-scraping of Claude token/cost data with a structured reader of Claude Code's JSONL session logs, and adds a turn-state–based "working" display signal plus a convergence ("stuck loop") warning. Subagents and todos are parsed but not yet rendered (explicit follow-on).
+- **One-line goal:** Replace fragile screen-scraping of Claude token/cost with a correct, structured reader of Claude Code's JSONL session logs; add a turn-state "working" display signal and a convergence ("stuck loop") warning — without ever perturbing the pipeline `active→done` edge.
 
-> **Rev 2 note.** Round 1 of red-teaming verified the original assumptions against the real logs on disk and refuted several. The biggest: Claude writes **one JSONL line per content block, each repeating the same `usage` object**, so a naive whole-file sum over-counts tokens/cost by ~2.6× — and the Agent-Dashboard parser this spec originally cited as "proven" has exactly that bug. Treat AD as a structural reference only, not a correctness oracle. All corrections are folded in below and called out with **[R1]**.
+> **Why Rev 3.** Round 1 refuted the naive token sum (per-block `usage` duplication → ~2.6× over-count) and the "id always known" assumption. Round 2 verified the dedup-by-id fix holds (measured 2.04–2.93×; zero id-less assistant lines; zero same-id usage conflicts; compaction-safe) and the `done`-edge decoupling holds (the queue reads `prevActivity`, never `GetTokens`), but found three remaining bugs and recommended decomposition. Rev 3 folds in all fixes, **cuts the over-engineered reader** (no worker pool, no incremental-delta summing), and splits the work into three independently-mergeable sub-plans. Findings tagged **[R1]/[R2]**.
 
-## Context
+---
 
-MTUI currently derives Claude token/cost/activity data by scraping the **rendered terminal screen** (`internal/terminal/activity.go`):
+## Shared model (applies to all sub-plans)
 
-- `ScanTokens()` matches `$\d+\.\d+` for cost and `"15.2k input"` / `"3.8k output"` regexes — only two token counters, no cache tokens, dependent on whatever Claude happens to print.
-- `DetectActivity()` / `classifyScreenState()` classify activity from prompt/question heuristics over the last 15 screen rows.
+### Format facts verified against real logs
 
-Claude Code already writes complete structured data to `~/.claude/projects/{encoded_path}/{sessionId}.jsonl`. Reading it directly yields exact tokens, per-model cost, subagent state, todos, and a turn-state — **if parsed correctly** (see the format hazards below).
+Verified against `C:\Users\PatrickHenniggoeComm\.claude\projects\D--repos-Multiterminal\` (64 jsonl, 6 branches) + siblings.
 
-**MTUI's structural advantage:** MTUI owns the PTY. It can know each session's working directory (`session.Dir`), and — when it launches Claude itself — the session id and start time. This removes the `ps`/`lsof` discovery layer that makes external monitors Unix-only; this design is Windows-native by construction. **[R1] But "MTUI always knows the session id at launch" is false** for several real launch paths (worktree panes, background agents, keepalive, restored sessions via `--resume`, and `claude` typed manually in a shell pane). The resolver must not assume it (see Components §1).
+1. **Per-block `usage` duplication [R1].** One API response (one `message.id`, one `usage`) is written as multiple JSONL lines — one per content block (`thinking`/`text`/`tool_use`) — each repeating the identical `usage`. **Token totals MUST dedup by `message.id`** (count each id once). Verified: 0/3676 assistant lines lack `message.id`; 0 same-id usage conflicts across all 64 files; compaction does not reuse ids.
+2. **~10 line types [R1].** Besides `assistant`/`user`/`system`: `mode`, `permission-mode`, `attachment`, `last-prompt`, `ai-title`, `file-history-snapshot`, `queue-operation`. Turn-state must consider only `user`/`assistant` lines.
+3. **Partial trailing line is the steady state during generation [R1].** The live file's last bytes are an unterminated append on nearly every read — normal, not an error.
+4. **Token field names (exact)** on `type:"assistant"` `message.usage`: `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`. Model at `message.model`.
+5. **tool_use/tool_result:** `tool_use`(`id`) in assistant `content[]`; matching `tool_result`(`tool_use_id`) in the next `user` line's `content[]`.
+6. **compact_boundary** (`type:"system", subtype:"compact_boundary"`). Per-message usage is per-turn → dedup-by-id sum is compaction-safe.
+7. **`cwd` + `gitBranch` exist in every file but never on the last line [R2].** In 53/64 files the last complete line is metadata (`permission-mode`/`ai-title`/…) carrying neither. Both fields appear ≤16 lines from EOF in every file (0/64 lack them entirely). The resolver must scan **backward** for the last complete line that has both.
+8. **Subagents:** `{sessionId}/subagents/*.jsonl` + sibling `*.meta.json` (`agentType`, `description`, `toolUseId`). **No `Status` field** — must be derived (deferred; ship empty).
+9. **TodoWrite:** shape unverified locally (no real TodoWrite call in these logs). Parse path written but `Todos` ships empty until a real fixture is captured.
 
-### Format hazards verified against real logs **[R1]**
+### Path encoding [R1]
 
-Verified against `C:\Users\PatrickHenniggoeComm\.claude\projects\D--repos-Multiterminal\` (64 jsonl files, 6 branches) and sibling projects:
+Claude encodes the abs path by replacing **`: \ / . _ ~ → -`** (the `~` is real: `C:\Users\PATRIC~1\…` → `C--Users-PATRIC-1-…`). Verified: `D:\repos\Multiterminal` → `D--repos-Multiterminal`; worktree `…\.worktrees\chat-pane-display-mode` → `…--worktrees-chat-pane-display-mode`. The encoding is **non-injective** (`.`,`_`,`-`,separators all → `-`): `a.b`, `a_b`, `a-b` collide. The resolver treats a >1-candidate match as ambiguous → no overwrite.
 
-1. **Per-block usage duplication (the critical one).** A single API response (one `message.id`, one `requestId`, one `usage`) is written as multiple JSONL lines — one per content block (`thinking`, `text`, `tool_use`) — and **each line repeats the identical `usage`**. Measured over-count: 2.0–2.7× across every file. The token sum **must deduplicate by `message.id`** (count each distinct id's usage once; occurrences are identical).
-2. **~10 line types, not 3.** Besides `assistant`/`user`/`system`, real files contain `mode`, `permission-mode`, `attachment`, `last-prompt`, `ai-title`, `file-history-snapshot`, `queue-operation`. Trailing lines are usually one of these, NOT `user`/`assistant`. Turn-state logic must consider only `user`/`assistant` lines and skip the rest.
-3. **Partial trailing line is the steady state during generation** — the live file's last bytes are an unterminated append on nearly every read. This is normal, not an error.
-4. **Token field names confirmed exact** on `type:"assistant"` `message.usage`: `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`. Model at `message.model` (e.g. `claude-opus-4-8`).
-5. **tool_use/tool_result pairing confirmed:** `tool_use` (with `id`) in an assistant line's `content[]`; matching `tool_result` (with `tool_use_id`) in the next `user` line's `content[]`.
-6. **compact_boundary confirmed** (`type:"system", subtype:"compact_boundary"`). Per-message usage is per-turn (not cumulative), so dedup-by-id summation is compaction-safe.
-7. **Subagents:** live in `{sessionId}/subagents/*.jsonl` with a sibling `*.meta.json` (`agentType`, `description`, `toolUseId`). There is **no `Status` field** in the data — status must be derived. Confirmed present on this machine.
-8. **TodoWrite todos:** shape (`tool_use.input.todos[] = {content, status, ...}`) is unconfirmed on this machine — no real TodoWrite call exists in local logs. A fixture from a real TodoWrite session is required before claiming todos work.
+### Pinned decisions [R2]
 
-### The Windows path-encoding finding
+| # | Decision | Value |
+|---|---|---|
+| D1 | `Confidence` type | `type Confidence int; const (ConfNone Confidence = iota; ConfLow; ConfHigh)`. **Zero value = `ConfNone`** (safe: never accidentally High). `Latest()` returns `SessionData` whose `Confidence==ConfNone` means "no usable data" (replaces a separate `ok`). |
+| D2 | Refresh cadence | **Tail-state** (turn-state, last tools, pending tool) recomputed **every scan tick** from the last ≤64 KB only. **Full token recompute** (whole-file dedup-by-id) at most **every 5 s**, or immediately when the file **shrank** (compaction). No per-read delta summing — full recompute rebuilds the id→usage map from scratch each time. |
+| D3 | Concurrency model | **One goroutine per Claude session** (pane count is capped by `max_panes_per_tab`). **No worker pool** (cut as premature). The scan loop only reads published last-known-good — non-blocking. |
+| D4 | Reader lifecycle owner | A `readerRegistry` owned by `AppService` (its own `sync.Mutex`, not `App.mu`). A reader is created lazily on the first `Latest(session)` for a Claude pane and torn down from the existing `cleanupActivityTracking(id)` site (`app.go:287`). |
+| D5 | "Is a Claude pane" predicate | The session's launch `mode` starts with `"claude"` **and** a non-empty `SessionID` was resolved. `codex`/`gemini` panes are out of scope for the foundation. |
+| D6 | Subagent `Status` | Ship `""` (unknown) in the foundation; derivation deferred to the visualization follow-on. |
+| D7 | Todos | Parse path implemented but `Todos` ships **empty** until a real TodoWrite fixture is captured. |
+| D8 | `CLAUDE_CONFIG_DIR` | Read **once** from the MTUI process env at startup; one config dir process-wide. No per-session override (documented limitation). |
 
-Claude encodes the absolute project path into the directory name by replacing separators/punctuation with `-`. Verified: `D:\repos\Multiterminal` → `D--repos-Multiterminal`; `D:\repos\Multiterminal\.worktrees\chat-pane-display-mode` → `D--repos-Multiterminal--worktrees-chat-pane-display-mode`. **[R1]** The real encoder also replaces **`~`** (real dir `C--Users-PATRIC-1-…` came from `PATRIC~1`). So the set is **`: \ / . _ ~ → -`**. The encoding is **non-injective** (`.`, `_`, `-`, separators all collapse to `-`): `D:\repos\a.b`, `…\a_b`, `…\a-b` all encode to `D--repos-a-b`. The resolver must treat a >1-candidate match as ambiguous (see §1).
+### Token totals — the only correct algorithm [R1/R2]
 
-## Goals
+```
+ids := map[string]Usage{}          // message.id -> usage (rebuilt every full recompute)
+for each COMPLETE line (terminated by \n):
+    if type=="assistant" && message.id != "":
+        ids[message.id] = message.usage   // identical on repeats; last-write is fine
+total := sum(ids)                   // each id counted once
+```
 
-1. Exact Claude token usage (four counters, **deduped by `message.id`**) and computed API-equivalent cost per pane, replacing the regex scrape when the JSONL is confidently resolved.
-2. A distinct **working** (generating) display signal derived from turn-state fused with PTY liveness — **as a display hint only, decoupled from the pipeline `done` edge**.
-3. A **convergence** warning flag when the agent repeats the same tool 5× in a row.
-4. Zero regression: non-Claude panes, unresolvable/ambiguous Claude sessions, and torn reads keep today's screen-scraping behavior via a soft fallback. **The pipeline queue/orchestrator `active→done` edge must behave byte-identically to today.**
+**No incremental delta. [R2]** 83 % of ids span >1 physical line (up to 13), so a "sum appended bytes" delta double-counts an id split across refreshes. The byte offset is used **only** for cheap tail-state, never for the token total. The full recompute reads the whole file on D2's cadence.
 
-## Non-Goals (deferred follow-ons)
+### Line framing — the only correct read [R1]
 
-- Rendering subagents/todos in the UI (parsed and shipped on the event; visualization is a separate plan).
-- `linesAdded` / `filesModified` / `gitCommits` / `toolErrors` extraction.
-- fsnotify watcher subsystem. (But the off-loop reader below is the stepping stone to it.)
-- Multi-provider (Codex/Gemini) parsing.
+Split the buffer on `\n`; **discard bytes after the last `\n`** (incomplete append). Never `Unmarshal` a partial line; a partial trailing line is **not** an error. Only a *complete* line that fails to parse is corruption → keep last-known-good, do not panic, do not log-spam.
 
-## Prerequisites (small enabling changes, tracked in the plan) **[R1]**
+---
 
-These do not exist today and must land first:
+## Sub-plan 1 — `claudelog` package (pure, stdlib only)
 
-1. **`Session.SessionID string`** — the Claude session id. Source of truth is the frontend tab-store pane field `claudeSessionId` (`frontend/src/stores/tabs.ts:25`); thread it through `CreateSession(...)` as an explicit parameter onto the struct. Do **not** rely on argv-parsing as the primary source. (Argv-parse in `Start` may serve as a secondary recovery, and must handle both `--session-id <uuid>` and `--session-id=<uuid>`.)
-2. **`Session.StartedAt time.Time`** — set in `Start()`. Required by the fallback resolver; only `LastOutputAt` exists today.
-3. **Pin the id on id-less launch sites** so they become resolvable: worktree panes (`App.svelte:392`), background agents (`background-agents.ts:56`), keepalive (`keepalive.ts:46`) must pass a generated `sessionId`.
-4. **Persist/expose `CLAUDE_CONFIG_DIR`** per session if MTUI is to honor an override: MTUI does not set it today and `Start` keeps the assembled env only as a local. Either capture the relevant env onto the session or accept `~/.claude` as the only supported location in this foundation (and document the limitation). Default decision: **support `~/.claude` and an explicit `CLAUDE_CONFIG_DIR` read from the MTUI process env**; per-session overrides are out of scope for the foundation.
-
-## Architecture
-
-New leaf package **`internal/terminal/claudelog`** — stdlib only, no backend imports, independently testable. Max 300 lines per file.
+A leaf package `internal/terminal/claudelog`, no backend imports, fully unit-tested with fixtures. **Zero product behavior change.** Max 300 lines/file.
 
 | File | Responsibility |
 |---|---|
-| `encode.go` | path encoder (`: \ / . _ ~ → -`), normalization, config-dir resolution |
-| `resolve.go` | session-file resolution + ambiguity detection |
-| `parse.go` | line framing, token sum (dedup by message.id), turn-state, tool tracking, subagents, todos |
-| `pricing.go` | `MODEL_PRICING` table + cost computation |
-| `reader.go` | per-session off-loop reader: cache, incremental offset, last-known-good `SessionData` |
-| `types.go` | result types |
-| `*_test.go` | per-file table tests + `testdata/*.jsonl` fixtures |
+| `types.go` | `TokenUsage`, `PendingTool`, `SubAgent`, `Todo`, `SessionData`, `Confidence` (D1) |
+| `encode.go` | `EncodePath` (`: \ / . _ ~ → -`, normalize: strip trailing sep), `ConfigDir()` (D8) |
+| `resolve.go` | `ResolveSessionFile(configDir, cwd, sessionID, startedAt) (path string, conf Confidence)` |
+| `parse.go` | line framing, dedup-by-id token total, turn-state (user/assistant only), pending tool, convergence, subagents (status=""), todos (empty per D7) |
+| `pricing.go` | `MODEL_PRICING` (per-1M incl. cache tiers), `CostUSD(model, TokenUsage)`, unknown→0 |
 
-### Data model (`types.go`)
+`ResolveSessionFile` order:
+1. projDir = `{configDir}/projects/{EncodePath(cwd)}`; cwd empty/`/` → `ConfNone`.
+2. `sessionID != ""` and `{projDir}/{sessionID}.jsonl` exists → `ConfHigh`.
+3. else list `{projDir}/*.jsonl`; for each, **scan backward for the last complete line carrying both `cwd` and `gitBranch`** (≤32 lines) and match against the session's dir/branch; among matches require mtime `> startedAt` (ns), newest wins → `ConfLow`; **0 or >1 matches → `ConfNone`** (ambiguous, never guess).
 
-```go
-type TokenUsage struct {
-    InputTokens, OutputTokens, CacheCreationTokens, CacheReadTokens int
-}
-type PendingTool struct { ID, Tool, Pattern string }
-type SubAgent struct { ID, Type, Description string; ToolUseID string; TokensUsed, DurationSeconds int; Status string /* derived */ }
-type Todo struct { Content, Status string }
+**Tests:** encoder (Windows paths, `PATRIC~1`→`PATRIC-1`, worktree, trailing sep, collisions→ambiguous); resolver (High by id; Low by cwd+gitBranch backward-scan; >1 match→None; missing dir); **token dedup with a multi-block same-`message.id` fixture** (the 2.6× regression guard) + compaction fixture; framing (partial last line ignored, valid prefix returned); turn-state (metadata-trailing must not flip `TurnOpen`; user-trailing open; pending-tool open; assistant-final closed; trailing-assistant-with-tool_use open); convergence; pricing (incl. cache tiers, unknown→0). `go test ./internal/terminal/claudelog/...` green.
 
-type SessionData struct {
-    SessionID, Model string
-    Tokens           TokenUsage   // deduped by message.id
-    CostUSD          float64
-    TurnOpen         bool         // agent owes next step; user/assistant lines only
-    PendingTool      *PendingTool
-    Convergence      bool
-    ConvergenceTool  string
-    Subagents        []SubAgent
-    Todos            []Todo
-    Confidence       Confidence   // High (id match) | Low (fallback guess)  [R1]
-    UpdatedAt        time.Time
-}
-```
+**Deliverable:** a tested library. Mergeable immediately, no behavior change.
 
-`Confidence` lets the caller refuse to overwrite good data with a low-confidence fallback guess.
+---
 
-## Components
+## Sub-plan 2 — Tokens/cost integration (the value increment)
 
-### 1. Encoder + resolver (`encode.go`, `resolve.go`) **[R1]**
+Delivers exact, deduped tokens/cost for the **already-id-pinned happy path** (launch-dialog and restored panes already emit `--session-id <uuid>` — verified `App.svelte:427`, `claude.ts:87`, `session.ts:30`).
 
-```go
-func EncodePath(absPath string) string   // normalize then replace : \ / . _ ~ → -
-func ConfigDir() string                  // CLAUDE_CONFIG_DIR (process env) or ~/.claude
-func ResolveSessionFile(configDir, cwd, sessionID string, startedAt time.Time) (path string, conf Confidence, ok bool)
-```
+**Minimal prerequisite — no frontend churn, no `CreateSession` signature change [R2]:**
+- Add `Session.SessionID string`, populated by **parsing `--session-id` out of the launch argv in `Start()`** (before the `cmd.exe /c` wrap). Handle both `--session-id <uuid>` and `--session-id=<uuid>`. MTUI emits the two-token form; manual/id-less launches simply leave it empty → those fall back to screen-scrape (handled in Sub-plan 3). This deliberately avoids touching the ~13 `CreateSession` call sites + 3 Wails binding files; canonical-field threading is deferred to Sub-plan 3 only if needed.
 
-`EncodePath` first **normalizes**: strip trailing separators, no case-fold of the drive letter is applied to the *encoded* string (NTFS lookup is case-insensitive, but the cache key must use the normalized form consistently).
+**Reader (simplest correct form, D3 deferred):** a **synchronous** `Latest(session) SessionData` that, on the scan tick, re-reads + caches last-known-good (full recompute gated by D2's 5 s / shrink rule; tail every tick). Off-loop goroutines are introduced in Sub-plan 3 — Sub-plan 2 ships the synchronous version to de-risk lock discipline first.
 
-Resolution order:
+**Wiring in `scanAllSessions`:**
+- `data := claudelog.Latest(session)` for Claude panes (D5).
+- If `data.Confidence == ConfHigh` → set `s.Tokens` (incl. new `CacheCreationTokens`/`CacheReadTokens`) + cost. Else → keep today's `ScanTokens()`. **Never overwrite good values with `ConfLow`/`ConfNone`.**
+- **Lock discipline [R1]:** read/parse entirely outside any session lock; acquire `s.mu` only for the final assignment; never hold `s.mu` across I/O.
+- **`done` edge untouched [R1/R2]:** the pipeline edge (`app_scan.go:157`) stays driven by `DetectActivity`/`HasHookData`, debounced by the existing 1.5 s gate. Tokens are a separate write the queue never reads.
 
-1. Project dir = `{configDir}/projects/{EncodePath(cwd)}`. cwd empty/`/` → not ok.
-2. **`sessionID` known** → `{projDir}/{sessionID}.jsonl` if it exists → `Confidence=High`. (Restored sessions resolve here too: `--resume <id>` keeps the same `<id>.jsonl`, verified.)
-3. **Unknown id** → list `{projDir}/*.jsonl`. To pick:
-   - Read the **last complete line** of each candidate and match its embedded `cwd` **and** `gitBranch` against the session's dir/branch. This kills cross-branch contamination (the dir mixes 6 branches' files).
-   - Among matches, require mtime **strictly >** `startedAt` (sub-second; Go exposes ns mtime on NTFS) and pick the newest. → `Confidence=Low`.
-   - If **zero or >1** candidates survive matching → `ok=false` (ambiguous) → caller keeps screen-scrape. Never guess under ambiguity.
+**Bindings:** extend `terminal.TokenInfo` with the two cache counters; **mirror into `frontend/wailsjs/go/models.ts`** (class field + constructor) — its own step (CLAUDE.md/memory recurring silent-strip bug).
 
-### 2. Parser (`parse.go`) **[R1]**
+**Tests:** the **scan-loop regression guard** — replay an append-by-append stream and assert `processQueue` fires **exactly once per turn** (never 0, never 2) with tokens changing underneath; **race test** (`-race`) running the reader concurrently with a `readLoop`-style writer to `s.LastOutputAt`, asserting no lock held across I/O; fallback (corrupt complete line / missing file → keep screen-scrape).
 
-**Line framing first:** split the read buffer on `\n`; **discard any bytes after the last `\n`** as an incomplete append. Never `Unmarshal` a partial line; never let a partial trailing line trigger the error/fallback path. Only a *complete* line that fails to parse counts as corruption.
+**Deliverable:** exact deduped tokens/cost for the happy path. Does **not** need `StartedAt`, the launch-site pins, or the working/convergence signal.
 
-- **Token total — dedup by `message.id`:** scan all complete lines; for each `type:"assistant"` line, key by `message.id` and record its `usage` once (occurrences are identical). Sum over distinct ids. Byte-prefilter on `"usage"`/`"compact_boundary"` to skip irrelevant lines cheaply. Compaction-safe (per-turn usage). **Validate the dedup with a multi-block fixture** — a same-`message.id`-across-3-lines case — or the test passes while still 2.6× wrong.
-- **Turn-state:** track the last line whose type ∈ {`user`,`assistant`}; ignore all metadata types. `TurnOpen = (lastRelevantType == "user") || (PendingTool != nil)`. `PendingTool` = most recent `tool_use` with no matching `tool_result`.
-- **Convergence:** last 5 recorded tool names identical → flag + name.
-- **Subagents:** enumerate `{projDir}/{sessionID}/subagents/*.jsonl` + `*.meta.json` sidecars; `Type←agentType`, link via `toolUseId`; `Status` **derived** (e.g. process/pid liveness or presence of a terminal record), not read.
-- **Todos:** last-write-wins over `TodoWrite` `tool_use.input.todos[]`. Gated behind a real fixture before being trusted.
+---
 
-Robustness: tolerate unknown fields; any I/O error (open/stat/read) or corrupt complete line → return last-known-good with `ok=false`, never panic, never log-spam.
+## Sub-plan 3 — Fallback coverage + working/convergence signal
 
-### 3. Pricing (`pricing.go`)
+Two independent slices; ship in either order.
 
-`MODEL_PRICING` map of per-1M-token rates incl. cache tiers; `CostUSD(model, TokenUsage) float64`. Unknown model → 0, no crash. Cost is an **API-equivalent estimate**, labeled as such in the UI.
+**3a — Low-confidence fallback + peripheral panes:**
+- Add `Session.StartedAt time.Time` (set in `Start()`); enables the `ConfLow` resolver's `mtime > startedAt` gate.
+- Pin `--session-id` on the three id-less sites so they become `ConfHigh`: worktree pane (`App.svelte:392`), background agents (`background-agents.ts:56`), keepalive (`keepalive.ts:46`) — each a one-liner mirroring the existing pinned path.
+- Upgrade the reader to **one goroutine per session** (D3) publishing last-known-good behind a small mutex; `Latest()` becomes a non-blocking read. Cache invalidation on `(size, mtime)`; on shrink → compaction → reset offset + full recompute; the ≤5 s full recompute also catches a same-size rewrite. On repeated read-deadline miss, downgrade `Confidence` so the caller reverts to live scrape.
 
-### 4. Off-loop reader + cache (`reader.go`) **[R1 — the key integration fix]**
+**3b — `working` + `convergence` display signal:**
+- Derive a display-only `working` state: JSONL `TurnOpen` (D2 tail) fused with `LastOutputAt < 1.5 s`. Priority for the *display* hint: hooks > JSONL(`ConfHigh`) > screen-scrape. **This never feeds the authoritative activity state or the `done` edge** — it is display-only.
+- `convergence` flag (last 5 tools identical) likewise display-only.
+- Extend the `ActivityInfo` event with `working bool`, `convergence bool` (+ parsed subagents/todos for later UI); **mirror into `models.ts`**. Frontend renders badges.
+- A transition table (inputs: `HasHookData`, `Confidence`, `TurnOpen`, `LastOutputAt<1.5 s` → display state) with tests asserting these fields never trigger `processQueue`.
 
-The reader does **not** run on the scan-loop goroutine. Each Claude session gets a lightweight reader that:
+**Deliverable:** worktree/background/keepalive panes resolve exactly; live "working" + stuck-loop badges.
 
-- Holds the last-known-good `SessionData`, published behind a small mutex / atomic pointer.
-- Refreshes on its own cadence (a worker pool with a hard per-read deadline, or a per-session goroutine), so a slow/large file never blocks other panes.
-- Uses an **incremental byte offset**: remember the last offset parsed; on refresh, read only appended bytes for the running token delta and tail state. A full recompute runs at a slow cadence (e.g. every N seconds), not every tick. This is the actual fix for "continuous append = permanent cache miss."
-- **Cache invalidation primarily on file size** (monotonic for an append log; more reliable than NTFS mtime). Tolerate **shrink/truncate** (compaction rewrites the file) by resetting the offset and re-reading.
-- **Eviction:** hook teardown into the existing `cleanupActivityTracking(id)` call site so closed sessions don't leak cache entries.
+---
 
-`scanAllSessions` only ever reads the published last-known-good struct — **non-blocking**.
+## Risks (residual)
 
-## Data flow (scan-loop integration) **[R1]**
+- **Schema drift** — Claude's JSONL is undocumented/version-dependent → isolated parser, tolerant unmarshal, soft fallback, fixtures pinned to a known CLI version.
+- **Low-confidence misattribution** — mitigated by backward cwd+gitBranch match + "ambiguous → don't guess"; residual only when two same-branch+cwd id-less sessions run concurrently → screen-scrape (acceptable).
+- **Cost** — API-equivalent estimate, labeled in UI.
+- **Todos** — unverified locally; ship empty until a fixture exists (D7).
 
-In `scanAllSessions` (`internal/backend/app_scan.go`), for Claude panes:
+## Follow-ons (out of scope)
 
-1. `data, ok := reader.Latest(session)` — non-blocking read of last-known-good.
-2. **Tokens/cost:** if `ok && data.Confidence==High` → set `s.Tokens` from `data` + `data.CostUSD`. Else (`Low`/`!ok`) → keep today's `ScanTokens()` regex; do **not** overwrite good values with a low-confidence guess.
-3. **Lock discipline:** the file read/parse happens entirely in the reader, off-loop and outside any session lock. `scanAllSessions` acquires `s.mu` **only** for the final `s.Tokens = …` assignment and releases immediately. Never hold `s.mu` across I/O (`activity.go` `ScanTokens` shape must not be extended to read files under its lock).
-
-**Activity — the `done` edge is sacrosanct:**
-
-- The pipeline edge (`activityChanged && actStr=="done"` → `processQueue` + `notifyOrchestratorDone`, `app_scan.go:157`) stays driven by the **existing** `DetectActivity` path, debounced by the existing 1.5s PTY-quiescence gate. **JSONL turn-state does NOT move or replace this edge in the foundation.**
-- The new **`working`** signal (JSONL `TurnOpen` fused with `LastOutputAt`) and **`convergence`** flag are **display-only**, emitted as additional fields on the activity event. They never trigger `processQueue`/`notifyOrchestratorDone`.
-- Priority for the *display* `working`/state hint: hooks (`HasHookData`) > JSONL (when `Confidence==High`) > screen-scrape. The *authoritative* activity state that gates the queue is unchanged.
-
-A transition table for the display hint (inputs: hasHookData, JSONL ok+Confidence, TurnOpen, LastOutputAt<1.5s → output state) is defined in the plan and covered by tests.
-
-### Struct & binding changes
-
-- Extend `terminal.TokenInfo` with `CacheCreationTokens`, `CacheReadTokens`.
-- Extend the `ActivityInfo` event payload with `working bool`, `convergence bool` (+ parsed subagents/todos for the follow-on UI).
-- **Mandatory (CLAUDE.md & memory — recurring silent-strip bug):** mirror every new field into `frontend/wailsjs/go/models.ts` (class field + constructor assignment). Tracked as its own plan step.
-
-## Testing **[R1 — adds the edge tests the v1 plan lacked]**
-
-- **Encoder:** Windows paths (`D:\…`, `C:\…`), `~`/8.3 (`PATRIC~1`→`PATRIC-1`), worktree paths, trailing separator, collision cases asserted as ambiguous.
-- **Resolver:** id-known High path; id-unknown fallback with cwd+gitBranch match; **two sessions same cwd different branch** → correct file or ambiguous; >1 match → `ok=false`; missing dir.
-- **Parser — token dedup:** a **multi-block, same-`message.id`** fixture asserting the sum counts the message once (the regression guard for the 2.6× bug). Plus compaction-boundary fixture.
-- **Parser — framing:** a fixture whose last line is a partial append → parser ignores it, returns valid data for the complete prefix, `ok` stays true.
-- **Parser — turn-state:** trailing metadata lines (`mode`, `system`, …) must not flip `TurnOpen`; user-trailing → open; pending-tool → open; assistant-final → closed. Convergence 5-identical / not.
-- **Subagents:** `.meta.json` sidecar parsing; derived status. **Todos:** behind a real fixture (acquire one first).
-- **Pricing:** per-model incl. cache tiers; unknown → 0.
-- **Scan-loop integration (the highest-stakes test):** replay an append-by-append JSONL stream through the actual activity-derivation and assert `processQueue` fires **exactly once per turn** — never zero, never twice — and that the `working`/`convergence` display fields never trigger it.
-- **Race:** run the reader concurrently with a `readLoop`-style writer to `s.LastOutputAt`/`s.Tokens` under `-race`; assert no lock held across I/O.
-- **Fallback:** corrupt complete line + missing file → `ok=false`, no crash, screen-scrape drives state.
-
-## Risks (residual, after fixes)
-
-- **Schema drift:** Claude's JSONL is undocumented and version-dependent → isolated parser, tolerant unmarshal, soft fallback, fixtures pinned to a known CLI version.
-- **Low-confidence misattribution:** mitigated by cwd+gitBranch matching and the "ambiguous → don't guess" rule; residual risk when two sessions on the same branch+cwd run concurrently without ids → falls back to screen-scrape (acceptable).
-- **Cost accuracy:** estimate only, labeled.
-- **Todos unverified locally** until a real fixture is captured.
-
-## Follow-ons (out of scope here)
-
-1. Subagent + todo visualization (pane / future Kanban card).
+1. Subagent + todo visualization (and `Status` derivation).
 2. `linesAdded`/`filesModified`/`gitCommits`/`toolErrors`.
-3. fsnotify watcher (replaces the off-loop reader's polling without changing callers).
+3. fsnotify watcher (replaces the per-session goroutine's polling without changing callers).
 4. Multi-provider (Codex/Gemini) resolution.
+
+---
+
+## Build order
+
+**Sub-plan 1 → Sub-plan 2 (value lands here) → Sub-plan 3a / 3b (either order).** Every step keeps the branch green: any unresolved/low-confidence/non-Claude pane keeps today's screen-scrape behavior by construction (Goal: zero regression).

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -11,8 +11,8 @@
 
 ## Spike findings (verified in code, 2026-06-23)
 
-1. **Attribution is free.** `CreateSession` injects `MULTITERMINAL_SESSION_ID=<id>` and `MTUI_PORT=<port>` into the PTY env (`internal/backend/app.go:205,208`). The statusline script runs as a descendant of the `claude` process inside that PTY, so it **inherits both**. `$env:MULTITERMINAL_SESSION_ID` maps a statusline invocation to the exact MTUI session — no file resolution, no encoder, no mtime race.
-2. **The return channel already exists.** A localhost HTTP server runs on `MTUI_PORT` (`internal/backend/app_tmux_api.go`, `http.NewServeMux`, `/api/tmux/log`). Adding `/api/statusline` is the same pattern.
+1. **Attribution is (almost) free.** `CreateSession` injects `MTUI_PORT=<port>` unconditionally (when the API is up) and `MULTITERMINAL_SESSION_ID=<id>` **for claude modes only** (`claude`/`claude-auto`/`claude-yolo` — `internal/backend/app.go:204-209`; it is NOT injected for shell/codex/gemini). Since only claude panes run the statusline, the gated set is exactly the set that matters. The statusline command runs as a descendant of the `claude` process inside that PTY, so it inherits both vars. `$MULTITERMINAL_SESSION_ID` maps a statusline invocation to the exact MTUI session — no file resolution, no encoder, no mtime race. **Caveat:** the PTY→`cmd.exe /c claude`→statusline env inheritance is inferred from code, **not yet run end-to-end** — Sub-plan 1 must verify it at runtime (see test list).
+2. **The return channel already exists, and so does the right forwarder pattern.** A localhost HTTP server runs on `MTUI_PORT` (`internal/backend/app_tmux_api.go`, `http.NewServeMux`, `/api/tmux/log`). MTUI already ships a **compiled Go shim** for exactly this kind of fire-and-forget POST: `cmd/tmux-shim/main.go` reads `MTUI_PORT` from env at runtime (line 35) and POSTs with `http.Client{Timeout: 2s}` (line 215). The exe directory is prepended to the PTY `PATH` (`session.go:123-133`), so a sibling forwarder binary is callable by name. Adding `/api/statusline` is the same pattern.
 3. **The official numbers are already on the wire.** MTUI installs `~/.claude/mtui-statusline.ps1` (`app_statusline.go`), invoked as `powershell -NonInteractive -NoProfile -File <script>` with Claude's JSON on stdin. The script already reads `$d.cost.total_cost_usd`, `$d.cost.total_duration_ms`, `$d.context_window.used_percentage`, `$d.model.display_name`, `$d.workspace.current_dir` — then `Write-Host`s and **discards** them. `total_cost_usd` is Claude's official cumulative cost (includes subagents). Claude's standard statusline schema also carries `session_id` and `transcript_path` (the absolute path to the session JSONL).
 4. **The pipeline `done` edge is independent of token state** (verified across earlier rounds): `app_scan.go:157` drives `processQueue`/`notifyOrchestratorDone` from `DetectActivity`/`HasHookData`; the queue reads `prevActivity`, never `GetTokens`. Feeding cost/tokens from a new source cannot perturb it. This invariant is preserved.
 
@@ -32,19 +32,23 @@ The statusline push is the primary, simple, accurate path and the value incremen
 ### Data flow — statusline capture (primary)
 
 ```
-Claude Code ──(JSON on stdin, per turn)──▶ mtui-statusline.ps1
-                                              │  reads $env:MULTITERMINAL_SESSION_ID, $env:MTUI_PORT
-                                              │  Write-Host (unchanged display)
-                                              └─ fire-and-forget POST raw JSON + sessionId
-                                                 to http://127.0.0.1:$MTUI_PORT/api/statusline
-                                                          │
-AppService /api/statusline handler ◀──────────────────────┘
-   parse → update Session{Cost, ContextPct, Model, Duration}, Confidence=High, set via s.mu (assignment only)
+Claude Code ──(JSON on stdin, per turn)──▶ statusline command
+                                              = mtui-statusline-forward.exe (Go shim)
+                                              │  reads $MTUI_PORT, $MULTITERMINAL_SESSION_ID (env, fresh)
+                                              │  tees stdin: ① pass through to the real statusline
+                                              │             (MTUI's PS1, or the user's pre-existing one)
+                                              │             → its stdout is the displayed status line
+                                              │  ② fire-and-forget POST {sessionId, rawJSON}
+                                              │     to http://127.0.0.1:$MTUI_PORT/api/statusline (2s client)
+                                              └────────────────────────────┐
+AppService /api/statusline handler ◀──────────────────────────────────────┘
+   parse → SetStatuslineData(sessionId, cost, ctx%, model, dur), costSource=statusline (assignment under s.mu)
 ```
 
-- **Forwarder (`buildStatusLineScript`):** after the existing `Write-Host`, append a guarded POST of the **entire raw stdin JSON** plus the MTUI session id. Must be **fire-and-forget and failure-silent** (try/catch, short timeout) — if MTUI is down or the port is stale, the statusline display must still render. Never let the forward break Claude's statusline.
-- **Endpoint (`/api/statusline`):** localhost only (same trust model as `/api/tmux/log`). Body = `{ sessionId int, payload <raw claude statusline json> }`. Handler parses `payload.cost.total_cost_usd`, `payload.context_window.used_percentage`, `payload.model.display_name`, `payload.cost.total_duration_ms`, and (if present) `payload.session_id`, `payload.transcript_path`.
-- **Session update:** set the cost/context/model fields on `Session` under `s.mu` (assignment only, no I/O under lock). Mark the cost source authoritative so the scan loop's `ScanTokens()` scrape does not overwrite it (see §Integration).
+- **Forwarder = a new compiled Go shim** `cmd/statusline-forward` (NOT PowerShell). PowerShell's `Invoke-RestMethod` is blocking and Claude **cancels the in-flight statusline command** if a new update arrives, so a blocking/hanging POST is actively harmful. The Go shim mirrors `cmd/tmux-shim`: reads `MTUI_PORT`/`MULTITERMINAL_SESSION_ID` from env, POSTs with a short-timeout `http.Client`, and **fails silently** (MTUI down / stale port → display still renders). Built alongside the main binary, lands in the exe dir already on `PATH`.
+- **Wrap, don't replace [fixes D7].** The shim **tees**: it forwards a copy of stdin to MTUI *and* pipes stdin to the real statusline command, relaying that command's stdout/exit so the user sees an unchanged status line. `applyStatusLine` registers the shim as the `statusLine.command`, passing the *previous* command (MTUI's `mtui-statusline.ps1`, or the user's pre-existing one captured from `ExistingCommand`) as the wrapped target. This makes capture work **regardless of whose statusline runs** — the power-user-with-custom-statusline case (previously a silent value-killer) is now covered.
+- **Endpoint (`/api/statusline`):** localhost only, POST-only, no auth/CORS (same trust model as `/api/tmux/log`; not browser-originated). Body = `{ sessionId int, payload <raw claude statusline json> }`. Handler parses `payload.cost.total_cost_usd`, `payload.context_window.used_percentage`, `payload.model.display_name`, `payload.cost.total_duration_ms`, and (if present) `payload.session_id`, `payload.transcript_path`. Finds the session via `a.sessions[id]` under `a.mu`.
+- **Session update:** a new `Session.SetStatuslineData(...)` setter (mirroring `SetHookActivity` in `session_hooks.go`) writes new `Session` fields (`StatuslineCost float64`, `ContextPct int`, `Model string`, + cache counters as available) under `s.mu` — assignment only, no I/O under lock — and sets `costSource = statusline` so the scan loop's `ScanTokens()` cannot clobber it (see Integration).
 
 ### Data flow — JSONL enrichment (secondary, smaller sub-plan)
 
@@ -61,23 +65,33 @@ A trimmed `internal/terminal/claudelog` package — **parse only, no resolve/enc
 | # | Decision | Value |
 |---|---|---|
 | D1 | Headline cost source | Statusline `total_cost_usd` (official, incl. subagents). No `pricing.go` reconstruction. |
-| D2 | Pane attribution | `$env:MULTITERMINAL_SESSION_ID` → MTUI session id. Direct; no JSONL resolution for cost. |
-| D3 | Forwarder failure mode | Fire-and-forget, failure-silent, short timeout. Statusline display must never break. |
+| D2 | Pane attribution | `$MULTITERMINAL_SESSION_ID` (env, claude-modes-only — `app.go:207`) → MTUI session id. Direct; no JSONL resolution for cost. |
+| D3 | Forwarder | A **compiled Go shim** `cmd/statusline-forward` (not PowerShell — Claude cancels in-flight statusline commands, so a blocking POST is harmful). Reads `MTUI_PORT` fresh from env, short-timeout `http.Client`, fails silently. **Tees** stdin to the wrapped real statusline so display is unchanged. |
+| D3b | Cross-restart staleness | Env vars are fixed per process; a claude pane from a previous app run holds the old `MTUI_PORT` and posts to a now-dead port → capture silently stops for that pane until relaunch (no corruption). Documented; acceptable. |
 | D4 | Cost source priority | statusline-push (`High`) > screen-scrape fallback. JSONL is **not** a cost source unless per-counter tokens are explicitly surfaced (then sums subagents too). |
 | D5 | "working"/convergence | Display-only signals, **decoupled from the `done` edge** (never trigger `processQueue`). |
 | D6 | JSONL file location | `transcript_path` (statusline payload) → else `HookSessionID()`. **No path encoder / cwd+gitBranch / mtime resolver.** |
-| D7 | User has own statusline | If MTUI did not install the statusline (`HasExisting` / not `IsOurs`), no push for that setup → fall back to screen-scrape. Documented limitation; offer to install in settings UI. |
+| D7 | User has own statusline | **Wrap it, don't skip it.** `applyStatusLine` registers the Go forwarder as `statusLine.command` and passes the previous command (`ExistingCommand`, or MTUI's PS1) as the wrapped target; the forwarder tees. Capture works for users with custom statuslines (ccusage/starship/etc.) too — the target audience. Only a user who removes the statusline entirely loses capture → screen-scrape fallback. |
 | D8 | Subagents/todos detail | Deferred to the visualization follow-on; not parsed in the foundation. |
 
 ## Sub-plans
 
 **Sub-plan 1 — Statusline capture (the value increment).**
-- Extend `buildStatusLineScript` with the guarded forwarder (D3).
-- Add `/api/statusline` to the existing localhost server; parse payload; update `Session` cost/context/model/duration (D1, D2), assignment under `s.mu` only.
-- Gate the existing `ScanTokens()` scrape so it does not overwrite a statusline-sourced cost (define one authoritative writer per tick).
-- Extend `ActivityInfo`/`TokenInfo` as needed for context %/model; **verify** whether the new fields cross a binding return (then sync `models.ts` per CLAUDE.md) or only an event (no sync) — they currently flow as the `terminal:activity` event payload, so likely no `models.ts` class change.
-- **Tests:** endpoint parses a real captured statusline JSON → correct Session fields; missing/garbage payload → no crash, no overwrite; the **`done`-edge regression guard** (replay activity transitions, assert `processQueue` fires exactly once per turn, unaffected by cost updates); forwarder POST is non-blocking.
-- **Deliverable:** accurate official cost + context % + model per pane, attributed exactly. Replaces the fragile regex for installed-statusline panes.
+- **Build `cmd/statusline-forward` (Go shim, D3):** reads `MTUI_PORT` + `MULTITERMINAL_SESSION_ID` from env; tees stdin → (a) pipes to the wrapped real statusline command (relaying its stdout + exit code), (b) fire-and-forget POST `{sessionId, rawJSON}` to `/api/statusline` with a short-timeout client, failing silently. Build it alongside the main binary so it lands in the exe dir (already on the PTY `PATH`).
+- **`applyStatusLine` wraps instead of installs-only-when-absent (D7):** register the forwarder as `statusLine.command`, passing the previous command (`ExistingCommand` if a user statusline exists, else MTUI's `mtui-statusline.ps1`) as the wrapped target.
+- **Add `/api/statusline`** to the existing localhost server (POST-only, loopback, no auth); parse payload; call a new `Session.SetStatuslineData(...)`.
+- **New `Session` fields + setter:** `StatuslineCost float64`, `ContextPct int`, `Model string` (+ a `costSource` enum: `scrape` | `statusline`). `SetStatuslineData` writes them under `s.mu` (assignment only) and sets `costSource = statusline`.
+- **Gate `ScanTokens()`** so it skips/does-not-overwrite cost when `costSource == statusline` (the single-authoritative-writer rule; `ScanTokens` runs unconditionally at `app_scan.go:106` today).
+- **Event/bindings:** extend the `terminal:activity` event payload (`ActivityInfo`) with context %/model; this flows as an **event**, not a binding return, so **no `models.ts` class sync needed** — but verify nothing new crosses a binding return (CLAUDE.md silent-strip rule applies only there).
+- **Tests / verification gates:**
+  - **(blocker) End-to-end env inheritance:** a real PTY → `cmd.exe /c claude` → forwarder run asserting `MULTITERMINAL_SESSION_ID` + `MTUI_PORT` are readable by the shim. Not a unit test — the inferred inheritance must be proven once.
+  - **(blocker) Forwarder non-blocking under cancellation:** the POST must detach/return fast enough that Claude killing the statusline mid-render does not drop the wrapped display nor hang.
+  - Endpoint parses a real captured statusline JSON → correct `Session` fields; missing/garbage payload → no crash, no overwrite.
+  - **`done`-edge regression guard:** replay activity transitions; assert `processQueue` fires exactly once per turn, unaffected by cost updates.
+  - `ScanTokens` does not overwrite a `statusline`-sourced cost.
+  - Wrapped statusline: user's existing command output still renders unchanged.
+- **Assumption to state:** all MTUI-launched claude panes run the interactive TUI (verified: `buildClaudeArgv` never emits `--print`/`-p`), so the statusline fires. A future headless pane would silently lose capture → screen-scrape.
+- **Deliverable:** accurate official cost (incl. subagents) + context % + model per pane, attributed exactly — for any pane with a statusline (MTUI's or the user's).
 
 **Sub-plan 2 — JSONL enrichment: "working" + convergence.**
 - Trimmed `claudelog` package: `parse.go` (tail framing, turn-state on user/assistant lines, pending-tool by forward id-match, convergence) + `types.go`. **No `encode.go`/`resolve.go`/`pricing.go`.**
@@ -91,8 +105,9 @@ A trimmed `internal/terminal/claudelog` package — **parse only, no resolve/enc
 
 ## Risks (residual)
 
-- **Statusline coverage:** only panes whose statusline MTUI installed push data (D7). Mitigation: screen-scrape fallback + an install prompt. Quantify in practice; the default MTUI-managed setup covers the common case.
-- **Statusline cadence:** updates per Claude turn, not continuously — fine for cost; live "working" comes from JSONL/PTY, not the statusline.
+- **Statusline coverage:** the wrap-existing forwarder (D7) covers MTUI's own statusline *and* a user's custom one; only a pane with no statusline at all loses capture → screen-scrape fallback. Cross-restart panes lose capture until relaunch (D3b).
+- **Statusline cadence:** Claude invokes the command after each assistant message / `/compact` / mode change, debounced ~300 ms — fine for cumulative cost; live "working" comes from JSONL/PTY, not the statusline.
+- **Headless panes:** statusline does not fire under `--print`/SDK mode; no MTUI claude pane uses that today, but a future one would silently fall back to screen-scrape.
 - **JSONL schema drift (Sub-plan 2 only):** isolated tail parser, tolerant unmarshal, soft fallback; far smaller surface now that resolution/pricing are gone.
 - **Localhost endpoint:** loopback only, same trust model as the existing tmux API; payload (cost/cwd) is local.
 

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -1,146 +1,108 @@
-# claudelog — JSONL Session Reader (Foundation)
+# Claude telemetry capture — statusline-primary, JSONL-enrichment (Foundation)
 
 - **Date:** 2026-06-23
-- **Status:** Rev 3 — decomposed into 3 sub-plans after red-team rounds 1 & 2 (all findings empirical against real logs)
+- **Status:** Rev 4 — re-sourced after a clean-start senior review + a verified spike. Supersedes the JSONL-first design of Rev 1–3.1.
 - **Branch target:** `alpha-main` (feature branch off it)
-- **One-line goal:** Replace fragile screen-scraping of Claude token/cost with a correct, structured reader of Claude Code's JSONL session logs; add a turn-state "working" display signal and a convergence ("stuck loop") warning — without ever perturbing the pipeline `active→done` edge.
+- **One-line goal:** Capture accurate Claude cost / context / model from the source MTUI already controls (its installed statusline), attributed to the exact pane; enrich with JSONL-derived signals (a "working" turn-state badge, convergence warning) only where the statusline can't provide them — without ever perturbing the pipeline `active→done` edge.
 
-> **Why Rev 3.** Round 1 refuted the naive token sum (per-block `usage` duplication → ~2.6× over-count) and the "id always known" assumption. Round 2 verified the dedup-by-id fix holds (measured 2.04–2.93×; zero id-less assistant lines; zero same-id usage conflicts; compaction-safe) and the `done`-edge decoupling holds (the queue reads `prevActivity`, never `GetTokens`), but found three remaining bugs and recommended decomposition. Rev 3 folds in all fixes, **cuts the over-engineered reader** (no worker pool, no incremental-delta summing), and splits the work into three independently-mergeable sub-plans. Findings tagged **[R1]/[R2]**.
+> **Why Rev 4 (the pivot).** Rev 1–3.1 built a transcript-JSONL reader (path encoder, file resolver, `pricing.go`, dedup-by-id) and red-teamed it across 3 rounds. A 4th, *unprimed* review found the design committed to the hardest, most fragile data source while cheaper, already-integrated sources sat unused in the same codebase — and that the JSONL token sum **undercounts cost by ~40 %+** because subagent spend lives in separate files (measured: main 6.78 M vs subagents 5.09 M tokens on one live session), whereas the thing it replaces (screen-scrape of Claude's printed total) already includes it. A spike then **verified** the better source. This rev re-sources accordingly. The cut machinery (encoder, resolver, pricing table) is gone from the critical path.
 
 ---
 
-## Shared model (applies to all sub-plans)
+## Spike findings (verified in code, 2026-06-23)
 
-### Format facts verified against real logs
+1. **Attribution is free.** `CreateSession` injects `MULTITERMINAL_SESSION_ID=<id>` and `MTUI_PORT=<port>` into the PTY env (`internal/backend/app.go:205,208`). The statusline script runs as a descendant of the `claude` process inside that PTY, so it **inherits both**. `$env:MULTITERMINAL_SESSION_ID` maps a statusline invocation to the exact MTUI session — no file resolution, no encoder, no mtime race.
+2. **The return channel already exists.** A localhost HTTP server runs on `MTUI_PORT` (`internal/backend/app_tmux_api.go`, `http.NewServeMux`, `/api/tmux/log`). Adding `/api/statusline` is the same pattern.
+3. **The official numbers are already on the wire.** MTUI installs `~/.claude/mtui-statusline.ps1` (`app_statusline.go`), invoked as `powershell -NonInteractive -NoProfile -File <script>` with Claude's JSON on stdin. The script already reads `$d.cost.total_cost_usd`, `$d.cost.total_duration_ms`, `$d.context_window.used_percentage`, `$d.model.display_name`, `$d.workspace.current_dir` — then `Write-Host`s and **discards** them. `total_cost_usd` is Claude's official cumulative cost (includes subagents). Claude's standard statusline schema also carries `session_id` and `transcript_path` (the absolute path to the session JSONL).
+4. **The pipeline `done` edge is independent of token state** (verified across earlier rounds): `app_scan.go:157` drives `processQueue`/`notifyOrchestratorDone` from `DetectActivity`/`HasHookData`; the queue reads `prevActivity`, never `GetTokens`. Feeding cost/tokens from a new source cannot perturb it. This invariant is preserved.
 
-Verified against `C:\Users\PatrickHenniggoeComm\.claude\projects\D--repos-Multiterminal\` (64 jsonl, 6 branches) + siblings.
+---
 
-1. **Per-block `usage` duplication [R1].** One API response (one `message.id`, one `usage`) is written as multiple JSONL lines — one per content block (`thinking`/`text`/`tool_use`) — each repeating the identical `usage`. **Token totals MUST dedup by `message.id`** (count each id once). Verified: 0/3676 assistant lines lack `message.id`; 0 same-id usage conflicts across all 64 files; compaction does not reuse ids.
-2. **~10 line types [R1].** Besides `assistant`/`user`/`system`: `mode`, `permission-mode`, `attachment`, `last-prompt`, `ai-title`, `file-history-snapshot`, `queue-operation`. Turn-state must consider only `user`/`assistant` lines.
-3. **Partial trailing line is the steady state during generation [R1].** The live file's last bytes are an unterminated append on nearly every read — normal, not an error.
-4. **Token field names (exact)** on `type:"assistant"` `message.usage`: `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`. Model at `message.model`.
-5. **tool_use/tool_result:** `tool_use`(`id`) in assistant `content[]`; matching `tool_result`(`tool_use_id`) in the next `user` line's `content[]`.
-6. **compact_boundary** (`type:"system", subtype:"compact_boundary"`). Per-message usage is per-turn → dedup-by-id sum is compaction-safe.
-7. **`cwd` + `gitBranch` exist in every file but never on the last line [R2].** In 53/64 files the last complete line is metadata (`permission-mode`/`ai-title`/…) carrying neither. Both fields appear ≤16 lines from EOF in every file (0/64 lack them entirely). The resolver must scan **backward** for the last complete line that has both.
-8. **Subagents:** `{sessionId}/subagents/*.jsonl` + sibling `*.meta.json` (`agentType`, `description`, `toolUseId`). **No `Status` field** — must be derived (deferred; ship empty).
-9. **TodoWrite:** shape unverified locally (no real TodoWrite call in these logs). Parse path written but `Todos` ships empty until a real fixture is captured.
+## Architecture
 
-### Path encoding [R1]
+Two sources, by what each is best at:
 
-Claude encodes the abs path by replacing **`: \ / . _ ~ → -`** (the `~` is real: `C:\Users\PATRIC~1\…` → `C--Users-PATRIC-1-…`). Verified: `D:\repos\Multiterminal` → `D--repos-Multiterminal`; worktree `…\.worktrees\chat-pane-display-mode` → `…--worktrees-chat-pane-display-mode`. The encoding is **non-injective** (`.`,`_`,`-`,separators all → `-`): `a.b`, `a_b`, `a-b` collide. The resolver treats a >1-candidate match as ambiguous → no overwrite.
+| Signal | Source | Why |
+|---|---|---|
+| **Total cost** (headline), **context %**, **model**, **duration** | **Statusline push** | Official `total_cost_usd` (incl. subagents); event-driven (no polling); attributed by `MULTITERMINAL_SESSION_ID`; no file resolution |
+| **"working" turn-state**, **convergence**, per-counter token breakdown, subagent/todo detail | **JSONL tail** (enrichment) | Not in the statusline payload; read the file located by `transcript_path` (from the statusline payload) or `HookSessionID()` — **never** by path-encoding/resolution |
 
-### Pinned decisions [R2]
+The statusline push is the primary, simple, accurate path and the value increment. JSONL becomes a smaller, optional enrichment whose file is *handed to us*, so the entire Rev-1–3 resolver/encoder is deleted.
+
+### Data flow — statusline capture (primary)
+
+```
+Claude Code ──(JSON on stdin, per turn)──▶ mtui-statusline.ps1
+                                              │  reads $env:MULTITERMINAL_SESSION_ID, $env:MTUI_PORT
+                                              │  Write-Host (unchanged display)
+                                              └─ fire-and-forget POST raw JSON + sessionId
+                                                 to http://127.0.0.1:$MTUI_PORT/api/statusline
+                                                          │
+AppService /api/statusline handler ◀──────────────────────┘
+   parse → update Session{Cost, ContextPct, Model, Duration}, Confidence=High, set via s.mu (assignment only)
+```
+
+- **Forwarder (`buildStatusLineScript`):** after the existing `Write-Host`, append a guarded POST of the **entire raw stdin JSON** plus the MTUI session id. Must be **fire-and-forget and failure-silent** (try/catch, short timeout) — if MTUI is down or the port is stale, the statusline display must still render. Never let the forward break Claude's statusline.
+- **Endpoint (`/api/statusline`):** localhost only (same trust model as `/api/tmux/log`). Body = `{ sessionId int, payload <raw claude statusline json> }`. Handler parses `payload.cost.total_cost_usd`, `payload.context_window.used_percentage`, `payload.model.display_name`, `payload.cost.total_duration_ms`, and (if present) `payload.session_id`, `payload.transcript_path`.
+- **Session update:** set the cost/context/model fields on `Session` under `s.mu` (assignment only, no I/O under lock). Mark the cost source authoritative so the scan loop's `ScanTokens()` scrape does not overwrite it (see §Integration).
+
+### Data flow — JSONL enrichment (secondary, smaller sub-plan)
+
+A trimmed `internal/terminal/claudelog` package — **parse only, no resolve/encode**:
+- File path is supplied: `transcript_path` from the statusline payload, else `HookSessionID()` → `{configDir}/projects/.../{uuid}.jsonl` (the uuid→filename mapping already used at `app_hooks.go:205`). If neither is known → no enrichment (cost still comes from the statusline).
+- Parses, from the tail (last ≤64 KB of complete `\n`-terminated lines):
+  - **turn-state** `TurnOpen` (last `user`/`assistant` line owes the next step; metadata line types skipped) → fused with `LastOutputAt` for a **display-only "working"** signal.
+  - **convergence** (last 5 tool names identical) → display-only warning.
+  - **pending tool** (a `tool_use` whose `tool_use_id` has no later `tool_result` — matched by id, scanning forward, not by adjacency).
+- **Token breakdown (optional, if we want the four counters):** full-file dedup-by-`message.id` sum **across the main file AND `{uuid}/subagents/*.jsonl`** (disjoint ids; one map). This is only needed if we surface per-counter tokens; the headline cost comes from the statusline regardless.
+
+## Pinned decisions
 
 | # | Decision | Value |
 |---|---|---|
-| D1 | `Confidence` type | `type Confidence int; const (ConfNone Confidence = iota; ConfLow; ConfHigh)`. **Zero value = `ConfNone`** (safe: never accidentally High). `Latest()` returns `SessionData` whose `Confidence==ConfNone` means "no usable data" (replaces a separate `ok`). |
-| D2 | Refresh cadence | **Tail-state** (turn-state, last tools, pending tool) recomputed **every scan tick** from the last ≤64 KB only. **Full token recompute** (whole-file dedup-by-id) at most **every 5 s**, or immediately when the file **shrank** (compaction). No per-read delta summing — full recompute rebuilds the id→usage map from scratch each time. |
-| D3 | Concurrency model | **One goroutine per Claude session** (pane count is capped by `max_panes_per_tab`). **No worker pool** (cut as premature). The scan loop only reads published last-known-good — non-blocking. |
-| D4 | Reader lifecycle owner | A `readerRegistry` owned by `AppService` (its own `sync.Mutex`, not `App.mu`). A reader is created lazily on the first `Latest(session)` for a Claude pane and torn down from the existing `cleanupActivityTracking(id)` site (`app.go:287`). |
-| D5 | "Is a Claude pane" predicate | **Effective predicate = `SessionID != ""` [R3].** `--session-id` is only ever emitted for claude modes, so a non-empty `SessionID` implies a claude pane. The Go `terminal.Session` has **no `mode` field today** (`mode` is only a `CreateSession` param for env/logging), so the predicate does not depend on one. `codex`/`gemini` out of scope. |
-| D6 | Subagent `Status` | Ship `""` (unknown) in the foundation; derivation deferred to the visualization follow-on. |
-| D7 | Todos | Parse path implemented but `Todos` ships **empty** until a real TodoWrite fixture is captured. |
-| D8 | `CLAUDE_CONFIG_DIR` | Read **once** from the MTUI process env at startup; one config dir process-wide. No per-session override (documented limitation). |
+| D1 | Headline cost source | Statusline `total_cost_usd` (official, incl. subagents). No `pricing.go` reconstruction. |
+| D2 | Pane attribution | `$env:MULTITERMINAL_SESSION_ID` → MTUI session id. Direct; no JSONL resolution for cost. |
+| D3 | Forwarder failure mode | Fire-and-forget, failure-silent, short timeout. Statusline display must never break. |
+| D4 | Cost source priority | statusline-push (`High`) > screen-scrape fallback. JSONL is **not** a cost source unless per-counter tokens are explicitly surfaced (then sums subagents too). |
+| D5 | "working"/convergence | Display-only signals, **decoupled from the `done` edge** (never trigger `processQueue`). |
+| D6 | JSONL file location | `transcript_path` (statusline payload) → else `HookSessionID()`. **No path encoder / cwd+gitBranch / mtime resolver.** |
+| D7 | User has own statusline | If MTUI did not install the statusline (`HasExisting` / not `IsOurs`), no push for that setup → fall back to screen-scrape. Documented limitation; offer to install in settings UI. |
+| D8 | Subagents/todos detail | Deferred to the visualization follow-on; not parsed in the foundation. |
 
-### Token totals — the only correct algorithm [R1/R2]
+## Sub-plans
 
-```
-ids := map[string]Usage{}          // message.id -> usage (rebuilt every full recompute)
-for each COMPLETE line (terminated by \n):
-    if type=="assistant" && message.id != "":
-        ids[message.id] = message.usage   // identical on repeats; last-write is fine
-total := sum(ids)                   // each id counted once
-```
+**Sub-plan 1 — Statusline capture (the value increment).**
+- Extend `buildStatusLineScript` with the guarded forwarder (D3).
+- Add `/api/statusline` to the existing localhost server; parse payload; update `Session` cost/context/model/duration (D1, D2), assignment under `s.mu` only.
+- Gate the existing `ScanTokens()` scrape so it does not overwrite a statusline-sourced cost (define one authoritative writer per tick).
+- Extend `ActivityInfo`/`TokenInfo` as needed for context %/model; **verify** whether the new fields cross a binding return (then sync `models.ts` per CLAUDE.md) or only an event (no sync) — they currently flow as the `terminal:activity` event payload, so likely no `models.ts` class change.
+- **Tests:** endpoint parses a real captured statusline JSON → correct Session fields; missing/garbage payload → no crash, no overwrite; the **`done`-edge regression guard** (replay activity transitions, assert `processQueue` fires exactly once per turn, unaffected by cost updates); forwarder POST is non-blocking.
+- **Deliverable:** accurate official cost + context % + model per pane, attributed exactly. Replaces the fragile regex for installed-statusline panes.
 
-**No incremental delta. [R2]** 72 % of ids span >1 physical line (up to 13), so a "sum appended bytes" delta double-counts an id split across refreshes. The byte offset is used **only** for cheap tail-state, never for the token total. The full recompute reads the whole file on D2's cadence.
+**Sub-plan 2 — JSONL enrichment: "working" + convergence.**
+- Trimmed `claudelog` package: `parse.go` (tail framing, turn-state on user/assistant lines, pending-tool by forward id-match, convergence) + `types.go`. **No `encode.go`/`resolve.go`/`pricing.go`.**
+- File path from `transcript_path` or `HookSessionID()` (D6).
+- Tail read off the scan-loop goroutine (per-session goroutine; non-blocking `Latest()`); display-only `working`/`convergence` fused with `LastOutputAt`, priority hooks > JSONL > scrape, **never feeding the authoritative activity state** (D5).
+- Extend `ActivityInfo` with `working bool`, `convergence bool`; transition-table tests asserting these never trigger `processQueue`.
+- **Deliverable:** live "generating" badge + stuck-loop warning.
 
-### Line framing — the only correct read [R1]
-
-Split the buffer on `\n`; **discard bytes after the last `\n`** (incomplete append). Never `Unmarshal` a partial line; a partial trailing line is **not** an error. Only a *complete* line that fails to parse is corruption → keep last-known-good, do not panic, do not log-spam.
-
----
-
-## Sub-plan 1 — `claudelog` package (pure, stdlib only)
-
-A leaf package `internal/terminal/claudelog`, no backend imports, fully unit-tested with fixtures. **Zero product behavior change.** Max 300 lines/file.
-
-| File | Responsibility |
-|---|---|
-| `types.go` | `TokenUsage`, `PendingTool`, `SubAgent`, `Todo`, `SessionData`, `Confidence` (D1) |
-| `encode.go` | `EncodePath` (`: \ / . _ ~ → -`, normalize: strip trailing sep), `ConfigDir()` (D8) |
-| `resolve.go` | `ResolveSessionFile(configDir, cwd, sessionID, startedAt) (path string, conf Confidence)` |
-| `parse.go` | line framing, dedup-by-id token total, turn-state (user/assistant only), pending tool, convergence, subagents (status=""), todos (empty per D7) |
-| `pricing.go` | `MODEL_PRICING` (per-1M incl. cache tiers), `CostUSD(model, TokenUsage)`, unknown→0 |
-
-`ResolveSessionFile` order:
-1. projDir = `{configDir}/projects/{EncodePath(cwd)}`; cwd empty/`/` → `ConfNone`.
-2. `sessionID != ""` and `{projDir}/{sessionID}.jsonl` exists → `ConfHigh`.
-3. else list `{projDir}/*.jsonl`; for each, **scan backward for the last complete line carrying both `cwd` and `gitBranch`** (≤32 lines; real max observed = 16) and match against the session's dir/branch (exact-string cwd; a deeper cwd such as `…\.worktrees\x\frontend` legitimately won't match → `ConfNone` → scrape). **Disambiguation [R3]:** 54/63 real files in one project share an identical `(cwd, gitBranch)`, so the match set is routinely large — the `mtime > startedAt` gate is the real disambiguator (only the live session's file is written after this session started); among files passing the gate, **newest mtime wins → `ConfLow`**. `ConfNone` only when **zero** files pass the gate **or** ≥2 pass with indistinguishable (sub-second-equal) mtimes — the true 1-second-race tie. Never guess on a tie.
-
-**Tests:** encoder (Windows paths, `PATRIC~1`→`PATRIC-1`, worktree, trailing sep, collisions→ambiguous); resolver (High by id; Low by cwd+gitBranch backward-scan; >1 match→None; missing dir); **token dedup with a multi-block same-`message.id` fixture** (the 2.6× regression guard) + compaction fixture; framing (partial last line ignored, valid prefix returned); turn-state (metadata-trailing must not flip `TurnOpen`; user-trailing open; pending-tool open; assistant-final closed; trailing-assistant-with-tool_use open); convergence; pricing (incl. cache tiers, unknown→0). `go test ./internal/terminal/claudelog/...` green.
-
-**Deliverable:** a tested library. Mergeable immediately, no behavior change.
-
----
-
-## Sub-plan 2 — Tokens/cost integration (the value increment)
-
-Delivers exact, deduped tokens/cost for the **already-id-pinned happy path** (launch-dialog and restored panes already emit `--session-id <uuid>` — verified `App.svelte:427`, `claude.ts:87`, `session.ts:30`).
-
-**Minimal prerequisite — no frontend churn, no `CreateSession` signature change [R2]:**
-- Add `Session.SessionID string`, populated by **parsing `--session-id` out of the launch argv in `Start()`** (before the `cmd.exe /c` wrap). Handle both `--session-id <uuid>` and `--session-id=<uuid>`. MTUI emits the two-token form; manual/id-less launches simply leave it empty → those fall back to screen-scrape (handled in Sub-plan 3). This deliberately avoids touching the ~13 `CreateSession` call sites + 3 Wails binding files; canonical-field threading is deferred to Sub-plan 3 only if needed.
-
-**Reader (simplest correct form, D3 deferred):** a **synchronous** `Latest(session) SessionData` that, on the scan tick, re-reads + caches last-known-good (full recompute gated by D2's 5 s / shrink rule; tail every tick). Off-loop goroutines are introduced in Sub-plan 3 — Sub-plan 2 ships the synchronous version to de-risk lock discipline first.
-
-**Wiring in `scanAllSessions`:**
-- `data := claudelog.Latest(session)` for Claude panes (D5).
-- If `data.Confidence == ConfHigh` → set `s.Tokens` (incl. new `CacheCreationTokens`/`CacheReadTokens`) + cost. Else → keep today's `ScanTokens()`. **Never overwrite good values with `ConfLow`/`ConfNone`.**
-- **Lock discipline [R1]:** read/parse entirely outside any session lock; acquire `s.mu` only for the final assignment; never hold `s.mu` across I/O.
-- **`done` edge untouched [R1/R2]:** the pipeline edge (`app_scan.go:157`) stays driven by `DetectActivity`/`HasHookData`, debounced by the existing 1.5 s gate. Tokens are a separate write the queue never reads.
-
-**Bindings [R3]:** extend `terminal.TokenInfo` with the two cache counters. Note: cost/activity currently reach the frontend as a plain `terminal:activity` **event payload** (`ActivityInfo{Cost string}`), not as a binding-return class — there is **no `TokenInfo`/`ActivityInfo` class in `models.ts` today**, so event payloads may need **no** `models.ts` change. The CLAUDE.md/memory silent-strip rule applies only to structs returned from binding methods; the plan step is "verify whether the new fields cross a binding return (sync `models.ts`) or only an event (no sync needed)", not a blind class edit.
-
-**Tests:** the **scan-loop regression guard** — replay an append-by-append stream and assert `processQueue` fires **exactly once per turn** (never 0, never 2) with tokens changing underneath; **race test** (`-race`) running the reader concurrently with a `readLoop`-style writer to `s.LastOutputAt`, asserting no lock held across I/O; fallback (corrupt complete line / missing file → keep screen-scrape).
-
-**Deliverable:** exact deduped tokens/cost for the happy path. Does **not** need `StartedAt`, the launch-site pins, or the working/convergence signal.
-
----
-
-## Sub-plan 3 — Fallback coverage + working/convergence signal
-
-Two independent slices; ship in either order.
-
-**3a — Low-confidence fallback + peripheral panes:**
-- Add `Session.StartedAt time.Time` (set in `Start()`); enables the `ConfLow` resolver's `mtime > startedAt` gate.
-- Pin `--session-id` on the three id-less sites so they become `ConfHigh`: worktree pane (`App.svelte:392`), background agents (`background-agents.ts:56`), keepalive (`keepalive.ts:46`) — each a one-liner mirroring the existing pinned path.
-- Upgrade the reader to **one goroutine per session** (D3) publishing last-known-good behind a small mutex; `Latest()` becomes a non-blocking read. Cache invalidation on `(size, mtime)`; on shrink → compaction → reset offset + full recompute; the ≤5 s full recompute also catches a same-size rewrite. On repeated read-deadline miss, downgrade `Confidence` so the caller reverts to live scrape.
-
-**3b — `working` + `convergence` display signal:**
-- Derive a display-only `working` state: JSONL `TurnOpen` (D2 tail) fused with `LastOutputAt < 1.5 s`. Priority for the *display* hint: hooks > JSONL(`ConfHigh`) > screen-scrape. **This never feeds the authoritative activity state or the `done` edge** — it is display-only.
-- `convergence` flag (last 5 tools identical) likewise display-only.
-- Extend the `ActivityInfo` event with `working bool`, `convergence bool` (+ parsed subagents/todos for later UI); **mirror into `models.ts`**. Frontend renders badges.
-- A transition table (inputs: `HasHookData`, `Confidence`, `TurnOpen`, `LastOutputAt<1.5 s` → display state) with tests asserting these fields never trigger `processQueue`.
-
-**Deliverable:** worktree/background/keepalive panes resolve exactly; live "working" + stuck-loop badges.
-
----
+**Sub-plan 3 — Subagent/todo detail + UI (follow-on).**
+- Per-counter token breakdown incl. subagents (dedup-by-id across main + `subagents/*.jsonl`), subagent roster, todo list, and their visualization. Captures the deferred D8 work when there's a consumer.
 
 ## Risks (residual)
 
-- **Schema drift** — Claude's JSONL is undocumented/version-dependent → isolated parser, tolerant unmarshal, soft fallback, fixtures pinned to a known CLI version.
-- **Low-confidence misattribution** — mitigated by backward cwd+gitBranch match + "ambiguous → don't guess"; residual only when two same-branch+cwd id-less sessions run concurrently → screen-scrape (acceptable).
-- **Cost** — API-equivalent estimate, labeled in UI.
-- **Todos** — unverified locally; ship empty until a fixture exists (D7).
+- **Statusline coverage:** only panes whose statusline MTUI installed push data (D7). Mitigation: screen-scrape fallback + an install prompt. Quantify in practice; the default MTUI-managed setup covers the common case.
+- **Statusline cadence:** updates per Claude turn, not continuously — fine for cost; live "working" comes from JSONL/PTY, not the statusline.
+- **JSONL schema drift (Sub-plan 2 only):** isolated tail parser, tolerant unmarshal, soft fallback; far smaller surface now that resolution/pricing are gone.
+- **Localhost endpoint:** loopback only, same trust model as the existing tmux API; payload (cost/cwd) is local.
 
 ## Follow-ons (out of scope)
 
-1. Subagent + todo visualization (and `Status` derivation).
-2. `linesAdded`/`filesModified`/`gitCommits`/`toolErrors`.
-3. fsnotify watcher (replaces the per-session goroutine's polling without changing callers).
-4. Multi-provider (Codex/Gemini) resolution.
-
----
+1. Subagent + todo visualization and per-counter token breakdown (Sub-plan 3).
+2. `linesAdded`/`filesModified`/`gitCommits` (the statusline payload exposes some of these — `cost.total_lines_added/removed` — capture opportunistically later).
+3. fsnotify watcher for the enrichment tail (replaces the per-session goroutine's polling).
+4. Multi-provider (Codex/Gemini) — they have their own statusline/telemetry stories.
 
 ## Build order
 
-**Sub-plan 1 → Sub-plan 2 (value lands here) → Sub-plan 3a / 3b (either order).** Every step keeps the branch green: any unresolved/low-confidence/non-Claude pane keeps today's screen-scrape behavior by construction (Goal: zero regression).
+**Sub-plan 1 (value lands here) → Sub-plan 2 → Sub-plan 3.** Every step keeps the branch green: any pane without a captured statusline push or resolvable JSONL keeps today's screen-scrape behavior by construction (zero-regression goal).

--- a/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md
@@ -1,185 +1,198 @@
 # claudelog — JSONL Session Reader (Foundation)
 
 - **Date:** 2026-06-23
-- **Status:** Approved design, pre-implementation
+- **Status:** Rev 2 — revised after red-team round 1 (empirical findings against real logs)
 - **Branch target:** `alpha-main` (feature branch off it)
-- **Scope:** Foundation only. Replaces fragile screen-scraping of Claude token/cost data with a structured reader of Claude Code's JSONL session logs, and adds a turn-state–based "working" signal plus a convergence ("stuck loop") warning. Subagents and todos are parsed but not yet rendered (explicit follow-on).
+- **Scope:** Foundation only. Replaces fragile screen-scraping of Claude token/cost data with a structured reader of Claude Code's JSONL session logs, and adds a turn-state–based "working" display signal plus a convergence ("stuck loop") warning. Subagents and todos are parsed but not yet rendered (explicit follow-on).
+
+> **Rev 2 note.** Round 1 of red-teaming verified the original assumptions against the real logs on disk and refuted several. The biggest: Claude writes **one JSONL line per content block, each repeating the same `usage` object**, so a naive whole-file sum over-counts tokens/cost by ~2.6× — and the Agent-Dashboard parser this spec originally cited as "proven" has exactly that bug. Treat AD as a structural reference only, not a correctness oracle. All corrections are folded in below and called out with **[R1]**.
 
 ## Context
 
 MTUI currently derives Claude token/cost/activity data by scraping the **rendered terminal screen** (`internal/terminal/activity.go`):
 
-- `ScanTokens()` matches `$\d+\.\d+` for cost and `"15.2k input"` / `"3.8k output"` regexes — only two token counters, no cache tokens, dependent on whatever Claude happens to print (theme, width, CLI version).
+- `ScanTokens()` matches `$\d+\.\d+` for cost and `"15.2k input"` / `"3.8k output"` regexes — only two token counters, no cache tokens, dependent on whatever Claude happens to print.
 - `DetectActivity()` / `classifyScreenState()` classify activity from prompt/question heuristics over the last 15 screen rows.
 
-This is inaccurate and version-fragile. Claude Code already writes complete, structured data to disk under `~/.claude/projects/{encoded_path}/{sessionId}.jsonl`. Reading it directly yields exact tokens (four counters), per-model cost, subagent state, todos, and a precise turn-state.
+Claude Code already writes complete structured data to `~/.claude/projects/{encoded_path}/{sessionId}.jsonl`. Reading it directly yields exact tokens, per-model cost, subagent state, todos, and a turn-state — **if parsed correctly** (see the format hazards below).
 
-**MTUI's structural advantage over external monitors (e.g. Agent-Dashboard):** MTUI owns the PTY. Critically, it **launches Claude with an explicit `--session-id <uuid>` flag** (verified in `CreateSession`: `claude.exe --dangerously-skip-permissions --session-id 4e8cc0b5-…`), so the session id is **deterministically known at launch** — no `ps`/`lsof` discovery, no hook dependency, no newest-file guess. It also knows the working directory (`session.Dir`) and start time. The whole external process-discovery layer that makes Agent-Dashboard Unix-only is unnecessary here — this design is Windows-native by construction.
+**MTUI's structural advantage:** MTUI owns the PTY. It can know each session's working directory (`session.Dir`), and — when it launches Claude itself — the session id and start time. This removes the `ps`/`lsof` discovery layer that makes external monitors Unix-only; this design is Windows-native by construction. **[R1] But "MTUI always knows the session id at launch" is false** for several real launch paths (worktree panes, background agents, keepalive, restored sessions via `--resume`, and `claude` typed manually in a shell pane). The resolver must not assume it (see Components §1).
+
+### Format hazards verified against real logs **[R1]**
+
+Verified against `C:\Users\PatrickHenniggoeComm\.claude\projects\D--repos-Multiterminal\` (64 jsonl files, 6 branches) and sibling projects:
+
+1. **Per-block usage duplication (the critical one).** A single API response (one `message.id`, one `requestId`, one `usage`) is written as multiple JSONL lines — one per content block (`thinking`, `text`, `tool_use`) — and **each line repeats the identical `usage`**. Measured over-count: 2.0–2.7× across every file. The token sum **must deduplicate by `message.id`** (count each distinct id's usage once; occurrences are identical).
+2. **~10 line types, not 3.** Besides `assistant`/`user`/`system`, real files contain `mode`, `permission-mode`, `attachment`, `last-prompt`, `ai-title`, `file-history-snapshot`, `queue-operation`. Trailing lines are usually one of these, NOT `user`/`assistant`. Turn-state logic must consider only `user`/`assistant` lines and skip the rest.
+3. **Partial trailing line is the steady state during generation** — the live file's last bytes are an unterminated append on nearly every read. This is normal, not an error.
+4. **Token field names confirmed exact** on `type:"assistant"` `message.usage`: `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`. Model at `message.model` (e.g. `claude-opus-4-8`).
+5. **tool_use/tool_result pairing confirmed:** `tool_use` (with `id`) in an assistant line's `content[]`; matching `tool_result` (with `tool_use_id`) in the next `user` line's `content[]`.
+6. **compact_boundary confirmed** (`type:"system", subtype:"compact_boundary"`). Per-message usage is per-turn (not cumulative), so dedup-by-id summation is compaction-safe.
+7. **Subagents:** live in `{sessionId}/subagents/*.jsonl` with a sibling `*.meta.json` (`agentType`, `description`, `toolUseId`). There is **no `Status` field** in the data — status must be derived. Confirmed present on this machine.
+8. **TodoWrite todos:** shape (`tool_use.input.todos[] = {content, status, ...}`) is unconfirmed on this machine — no real TodoWrite call exists in local logs. A fixture from a real TodoWrite session is required before claiming todos work.
 
 ### The Windows path-encoding finding
 
-Claude encodes the absolute project path into the project directory name by replacing path separators and punctuation with `-`. On Windows this includes the drive colon and backslash, which a Unix-only encoder (like Agent-Dashboard's, which only replaces `/`, `.`, `_`) does not handle. Verified on the target machine:
-
-```
-D:\repos\Multiterminal  →  ~/.claude/projects/D--repos-Multiterminal/
-```
-
-So the encoder must replace **`:`, `\`, `/`, `.`, `_` → `-`**. The logs for this very project already exist on disk, so the approach is validated on Windows.
+Claude encodes the absolute project path into the directory name by replacing separators/punctuation with `-`. Verified: `D:\repos\Multiterminal` → `D--repos-Multiterminal`; `D:\repos\Multiterminal\.worktrees\chat-pane-display-mode` → `D--repos-Multiterminal--worktrees-chat-pane-display-mode`. **[R1]** The real encoder also replaces **`~`** (real dir `C--Users-PATRIC-1-…` came from `PATRIC~1`). So the set is **`: \ / . _ ~ → -`**. The encoding is **non-injective** (`.`, `_`, `-`, separators all collapse to `-`): `D:\repos\a.b`, `…\a_b`, `…\a-b` all encode to `D--repos-a-b`. The resolver must treat a >1-candidate match as ambiguous (see §1).
 
 ## Goals
 
-1. Exact Claude token usage (input / output / cache-creation / cache-read) and computed API-equivalent cost per pane, replacing the regex scrape when JSONL is resolvable.
-2. A distinct **working** (generating now) vs. **owes-you** (waiting on user) signal derived from conversation turn-state.
-3. A **convergence** warning flag when the agent repeats the same tool 5× in a row (stuck loop).
-4. Zero regression: non-Claude panes and unresolvable Claude sessions keep today's screen-scraping behavior via a soft fallback.
+1. Exact Claude token usage (four counters, **deduped by `message.id`**) and computed API-equivalent cost per pane, replacing the regex scrape when the JSONL is confidently resolved.
+2. A distinct **working** (generating) display signal derived from turn-state fused with PTY liveness — **as a display hint only, decoupled from the pipeline `done` edge**.
+3. A **convergence** warning flag when the agent repeats the same tool 5× in a row.
+4. Zero regression: non-Claude panes, unresolvable/ambiguous Claude sessions, and torn reads keep today's screen-scraping behavior via a soft fallback. **The pipeline queue/orchestrator `active→done` edge must behave byte-identically to today.**
 
 ## Non-Goals (deferred follow-ons)
 
-- Rendering subagents and todos in the UI (they are parsed into `SessionData` and shipped on the activity event, but UI visualization is a separate plan).
-- `linesAdded` / `filesModified` / `gitCommits` / `toolErrors` extraction (cheap to add to the same parse pass later; no foundation value).
-- A real-time fsnotify watcher subsystem (Approach C). Polling within the existing scan loop is the foundation; the package API must not preclude a later watcher.
-- Multi-provider (Codex/Gemini) JSONL parsing.
+- Rendering subagents/todos in the UI (parsed and shipped on the event; visualization is a separate plan).
+- `linesAdded` / `filesModified` / `gitCommits` / `toolErrors` extraction.
+- fsnotify watcher subsystem. (But the off-loop reader below is the stepping stone to it.)
+- Multi-provider (Codex/Gemini) parsing.
+
+## Prerequisites (small enabling changes, tracked in the plan) **[R1]**
+
+These do not exist today and must land first:
+
+1. **`Session.SessionID string`** — the Claude session id. Source of truth is the frontend tab-store pane field `claudeSessionId` (`frontend/src/stores/tabs.ts:25`); thread it through `CreateSession(...)` as an explicit parameter onto the struct. Do **not** rely on argv-parsing as the primary source. (Argv-parse in `Start` may serve as a secondary recovery, and must handle both `--session-id <uuid>` and `--session-id=<uuid>`.)
+2. **`Session.StartedAt time.Time`** — set in `Start()`. Required by the fallback resolver; only `LastOutputAt` exists today.
+3. **Pin the id on id-less launch sites** so they become resolvable: worktree panes (`App.svelte:392`), background agents (`background-agents.ts:56`), keepalive (`keepalive.ts:46`) must pass a generated `sessionId`.
+4. **Persist/expose `CLAUDE_CONFIG_DIR`** per session if MTUI is to honor an override: MTUI does not set it today and `Start` keeps the assembled env only as a local. Either capture the relevant env onto the session or accept `~/.claude` as the only supported location in this foundation (and document the limitation). Default decision: **support `~/.claude` and an explicit `CLAUDE_CONFIG_DIR` read from the MTUI process env**; per-session overrides are out of scope for the foundation.
 
 ## Architecture
 
-New leaf package **`internal/terminal/claudelog`** — depends only on the standard library, no backend imports, independently testable. Max 300 lines per file (project rule).
+New leaf package **`internal/terminal/claudelog`** — stdlib only, no backend imports, independently testable. Max 300 lines per file.
 
 | File | Responsibility |
 |---|---|
-| `encode.go` | Windows-aware path encoder + JSONL session-file resolution |
-| `parse.go` | JSONL line parsing: token sum, turn-state, tool tracking, subagents, todos |
+| `encode.go` | path encoder (`: \ / . _ ~ → -`), normalization, config-dir resolution |
+| `resolve.go` | session-file resolution + ambiguity detection |
+| `parse.go` | line framing, token sum (dedup by message.id), turn-state, tool tracking, subagents, todos |
 | `pricing.go` | `MODEL_PRICING` table + cost computation |
-| `types.go` | `SessionData` and nested result types |
+| `reader.go` | per-session off-loop reader: cache, incremental offset, last-known-good `SessionData` |
+| `types.go` | result types |
 | `*_test.go` | per-file table tests + `testdata/*.jsonl` fixtures |
 
 ### Data model (`types.go`)
 
 ```go
 type TokenUsage struct {
-    InputTokens         int
-    OutputTokens        int
-    CacheCreationTokens int
-    CacheReadTokens     int
+    InputTokens, OutputTokens, CacheCreationTokens, CacheReadTokens int
 }
-
-type PendingTool struct {
-    ID      string
-    Tool    string
-    Pattern string // command or file path the agent is blocked on
-}
-
-type SubAgent struct {
-    ID              string
-    Type            string
-    Status          string
-    CurrentAction   string
-    TokensUsed      int
-    DurationSeconds int
-}
-
-type Todo struct {
-    Subject string
-    Status  string // pending | in_progress | completed
-}
+type PendingTool struct { ID, Tool, Pattern string }
+type SubAgent struct { ID, Type, Description string; ToolUseID string; TokensUsed, DurationSeconds int; Status string /* derived */ }
+type Todo struct { Content, Status string }
 
 type SessionData struct {
-    SessionID       string
-    Model           string
-    Tokens          TokenUsage
-    CostUSD         float64
-    TurnOpen        bool          // agent owes the next step
-    PendingTool     *PendingTool  // last tool_use without a matching tool_result
-    Convergence     bool          // last 5 tool calls identical
-    ConvergenceTool string
-    Subagents       []SubAgent
-    Todos           []Todo
-    UpdatedAt       time.Time
+    SessionID, Model string
+    Tokens           TokenUsage   // deduped by message.id
+    CostUSD          float64
+    TurnOpen         bool         // agent owes next step; user/assistant lines only
+    PendingTool      *PendingTool
+    Convergence      bool
+    ConvergenceTool  string
+    Subagents        []SubAgent
+    Todos            []Todo
+    Confidence       Confidence   // High (id match) | Low (fallback guess)  [R1]
+    UpdatedAt        time.Time
 }
 ```
+
+`Confidence` lets the caller refuse to overwrite good data with a low-confidence fallback guess.
 
 ## Components
 
-### 1. Encoder + resolver (`encode.go`)
+### 1. Encoder + resolver (`encode.go`, `resolve.go`) **[R1]**
 
 ```go
-func EncodePath(absPath string) string            // replace : \ / . _ → -
-func ConfigDir(ptyEnv []string) string            // CLAUDE_CONFIG_DIR or ~/.claude
-func ResolveSessionFile(configDir, cwd, sessionID, hookSessionID string, startedAt time.Time) (string, bool)
+func EncodePath(absPath string) string   // normalize then replace : \ / . _ ~ → -
+func ConfigDir() string                  // CLAUDE_CONFIG_DIR (process env) or ~/.claude
+func ResolveSessionFile(configDir, cwd, sessionID string, startedAt time.Time) (path string, conf Confidence, ok bool)
 ```
 
-Resolution order (most authoritative first):
+`EncodePath` first **normalizes**: strip trailing separators, no case-fold of the drive letter is applied to the *encoded* string (NTFS lookup is case-insensitive, but the cache key must use the normalized form consistently).
 
-1. Project dir = `{configDir}/projects/{EncodePath(cwd)}`.
-2. **`sessionID` from the session's own launch argv** (MTUI passes `--session-id <uuid>`) → `{projDir}/{sessionID}.jsonl`. This is the primary, deterministic path.
-3. Fallback `hookSessionID` (if set by hooks and `sessionID` was unavailable) → `{projDir}/{hookSessionID}.jsonl`.
-4. Last-resort fallback → list `{projDir}/*.jsonl`, pick newest mtime where `mtime >= startedAt`. Covers sessions MTUI did not launch with an explicit id (e.g. restored/attached).
-5. cwd empty or `/` → no file (skip).
+Resolution order:
 
-> Implementation note: the session id must be threaded from the launch argv onto the `Session` struct (parse the `--session-id` value in `Start`, store it). This is a small prerequisite tracked in the implementation plan.
+1. Project dir = `{configDir}/projects/{EncodePath(cwd)}`. cwd empty/`/` → not ok.
+2. **`sessionID` known** → `{projDir}/{sessionID}.jsonl` if it exists → `Confidence=High`. (Restored sessions resolve here too: `--resume <id>` keeps the same `<id>.jsonl`, verified.)
+3. **Unknown id** → list `{projDir}/*.jsonl`. To pick:
+   - Read the **last complete line** of each candidate and match its embedded `cwd` **and** `gitBranch` against the session's dir/branch. This kills cross-branch contamination (the dir mixes 6 branches' files).
+   - Among matches, require mtime **strictly >** `startedAt` (sub-second; Go exposes ns mtime on NTFS) and pick the newest. → `Confidence=Low`.
+   - If **zero or >1** candidates survive matching → `ok=false` (ambiguous) → caller keeps screen-scrape. Never guess under ambiguity.
 
-### 2. Parser (`parse.go`)
+### 2. Parser (`parse.go`) **[R1]**
 
-Two-tier read (pattern proven by Agent-Dashboard's parser):
+**Line framing first:** split the read buffer on `\n`; **discard any bytes after the last `\n`** as an incomplete append. Never `Unmarshal` a partial line; never let a partial trailing line trigger the error/fallback path. Only a *complete* line that fails to parse counts as corruption.
 
-- **Tail read — last 32 KB** for live state: pair `tool_use`↔`tool_result`, record the trailing entry type, the last N tool names, subagent references, todos (from `TodoWrite` tool inputs), and the model.
-  - `TurnOpen = (lastEntryType == "user") || (PendingTool != nil)`.
-  - `PendingTool` = the most recent `tool_use` with no matching `tool_result`.
-  - `Convergence` = the last 5 recorded tool names are all identical → set flag + `ConvergenceTool`.
-- **Full-file token sum** for authoritative totals: byte-level prefilter (only unmarshal lines containing `"usage"` or `"compact_boundary"`), sum every assistant message's per-message usage across the whole file (compaction-safe). The 32 KB tail cannot be trusted for totals on long/compacted sessions.
+- **Token total — dedup by `message.id`:** scan all complete lines; for each `type:"assistant"` line, key by `message.id` and record its `usage` once (occurrences are identical). Sum over distinct ids. Byte-prefilter on `"usage"`/`"compact_boundary"` to skip irrelevant lines cheaply. Compaction-safe (per-turn usage). **Validate the dedup with a multi-block fixture** — a same-`message.id`-across-3-lines case — or the test passes while still 2.6× wrong.
+- **Turn-state:** track the last line whose type ∈ {`user`,`assistant`}; ignore all metadata types. `TurnOpen = (lastRelevantType == "user") || (PendingTool != nil)`. `PendingTool` = most recent `tool_use` with no matching `tool_result`.
+- **Convergence:** last 5 recorded tool names identical → flag + name.
+- **Subagents:** enumerate `{projDir}/{sessionID}/subagents/*.jsonl` + `*.meta.json` sidecars; `Type←agentType`, link via `toolUseId`; `Status` **derived** (e.g. process/pid liveness or presence of a terminal record), not read.
+- **Todos:** last-write-wins over `TodoWrite` `tool_use.input.todos[]`. Gated behind a real fixture before being trusted.
 
-Robustness: the JSONL schema is undocumented and version-dependent. Tolerate unknown fields; on any parse error, return `(nil, false)` so the caller falls back to screen-scraping. Never panic, never emit zeroed-out data that would overwrite good screen-scrape values.
+Robustness: tolerate unknown fields; any I/O error (open/stat/read) or corrupt complete line → return last-known-good with `ok=false`, never panic, never log-spam.
 
 ### 3. Pricing (`pricing.go`)
 
-```go
-var MODEL_PRICING = map[string]Pricing{ /* per-1M-token rates incl. cache tiers */ }
-func CostUSD(model string, t TokenUsage) float64
-```
+`MODEL_PRICING` map of per-1M-token rates incl. cache tiers; `CostUSD(model, TokenUsage) float64`. Unknown model → 0, no crash. Cost is an **API-equivalent estimate**, labeled as such in the UI.
 
-Cost is **API-equivalent estimate**, not actual billing for Pro/Max plans — surfaced as such in the UI.
+### 4. Off-loop reader + cache (`reader.go`) **[R1 — the key integration fix]**
 
-### 4. Caching
+The reader does **not** run on the scan-loop goroutine. Each Claude session gets a lightweight reader that:
 
-Cache the resolved file path + file identity (size, mtime) keyed by **MTUI session ID**. The expensive full-file token scan runs only on a cache miss (file changed). TTL ≈ the scan interval. The package API must remain pure (`Read(args) → SessionData`) so a later fsnotify watcher can replace polling without changing callers.
+- Holds the last-known-good `SessionData`, published behind a small mutex / atomic pointer.
+- Refreshes on its own cadence (a worker pool with a hard per-read deadline, or a per-session goroutine), so a slow/large file never blocks other panes.
+- Uses an **incremental byte offset**: remember the last offset parsed; on refresh, read only appended bytes for the running token delta and tail state. A full recompute runs at a slow cadence (e.g. every N seconds), not every tick. This is the actual fix for "continuous append = permanent cache miss."
+- **Cache invalidation primarily on file size** (monotonic for an append log; more reliable than NTFS mtime). Tolerate **shrink/truncate** (compaction rewrites the file) by resetting the offset and re-reading.
+- **Eviction:** hook teardown into the existing `cleanupActivityTracking(id)` call site so closed sessions don't leak cache entries.
 
-## Data flow (scan-loop integration)
+`scanAllSessions` only ever reads the published last-known-good struct — **non-blocking**.
+
+## Data flow (scan-loop integration) **[R1]**
 
 In `scanAllSessions` (`internal/backend/app_scan.go`), for Claude panes:
 
-1. `data, ok := claudelog.Read(session)`.
-2. **Tokens/cost:** if `ok` → set `s.Tokens` from `data` (four counters) and cost from `data.CostUSD`. Else → keep today's `ScanTokens()` regex as fallback.
-3. **Activity — additive priority, existing logic preserved:**
-   1. **Hooks** (`HasHookData()`) — unchanged, highest authority (permission/stop).
-   2. **JSONL turn-state** — *new*: provides the fine **working** (generating) vs. **owes-you** (waiting on user) distinction. Fused with PTY liveness: recent PTY output (existing `LastOutputAt` < ~1.5 s gate) → generating; turn closed + quiesced → done/waiting.
-   3. **Screen-scrape** (`DetectActivity`) — fallback for non-Claude / unresolved sessions.
-4. **Convergence** is a separate warning flag (not an `ActivityState`) surfaced as a badge.
+1. `data, ok := reader.Latest(session)` — non-blocking read of last-known-good.
+2. **Tokens/cost:** if `ok && data.Confidence==High` → set `s.Tokens` from `data` + `data.CostUSD`. Else (`Low`/`!ok`) → keep today's `ScanTokens()` regex; do **not** overwrite good values with a low-confidence guess.
+3. **Lock discipline:** the file read/parse happens entirely in the reader, off-loop and outside any session lock. `scanAllSessions` acquires `s.mu` **only** for the final `s.Tokens = …` assignment and releases immediately. Never hold `s.mu` across I/O (`activity.go` `ScanTokens` shape must not be extended to read files under its lock).
+
+**Activity — the `done` edge is sacrosanct:**
+
+- The pipeline edge (`activityChanged && actStr=="done"` → `processQueue` + `notifyOrchestratorDone`, `app_scan.go:157`) stays driven by the **existing** `DetectActivity` path, debounced by the existing 1.5s PTY-quiescence gate. **JSONL turn-state does NOT move or replace this edge in the foundation.**
+- The new **`working`** signal (JSONL `TurnOpen` fused with `LastOutputAt`) and **`convergence`** flag are **display-only**, emitted as additional fields on the activity event. They never trigger `processQueue`/`notifyOrchestratorDone`.
+- Priority for the *display* `working`/state hint: hooks (`HasHookData`) > JSONL (when `Confidence==High`) > screen-scrape. The *authoritative* activity state that gates the queue is unchanged.
+
+A transition table for the display hint (inputs: hasHookData, JSONL ok+Confidence, TurnOpen, LastOutputAt<1.5s → output state) is defined in the plan and covered by tests.
 
 ### Struct & binding changes
 
 - Extend `terminal.TokenInfo` with `CacheCreationTokens`, `CacheReadTokens`.
-- Extend the `ActivityInfo` event payload with `working bool` and `convergence bool` (and ship parsed subagents/todos for the follow-on UI).
-- **Mandatory (per CLAUDE.md & memory — recurring silent-strip bug):** manually mirror every new field into `frontend/wailsjs/go/models.ts` (class field declaration + constructor assignment). Tracked as its own plan step.
+- Extend the `ActivityInfo` event payload with `working bool`, `convergence bool` (+ parsed subagents/todos for the follow-on UI).
+- **Mandatory (CLAUDE.md & memory — recurring silent-strip bug):** mirror every new field into `frontend/wailsjs/go/models.ts` (class field + constructor assignment). Tracked as its own plan step.
 
-## Testing
+## Testing **[R1 — adds the edge tests the v1 plan lacked]**
 
-- **Encoder:** table tests with Windows paths (`D:\repos\…`, `C:\Users\…`), a worktree path, empty cwd.
-- **Resolver:** hook-id path vs. newest-file path; two sessions in one cwd disambiguated by `startedAt`; missing project dir.
-- **Parser:** token sum across a compaction boundary; turn-state open/closed; pending tool; convergence (5 identical / not); subagents; todos. Own `testdata/*.jsonl` fixtures.
-- **Pricing:** per-model incl. cache tiers; unknown model → 0 (no crash).
-- **Integration:** a fake `~/.claude/projects/…` tree + a fake `Session` with `Dir` set → assert `SessionData`.
-- **Fallback:** corrupt/truncated JSONL → `(nil, false)`, no crash, screen-scrape still drives state.
-- `go test ./internal/terminal/...` green under the race detector.
+- **Encoder:** Windows paths (`D:\…`, `C:\…`), `~`/8.3 (`PATRIC~1`→`PATRIC-1`), worktree paths, trailing separator, collision cases asserted as ambiguous.
+- **Resolver:** id-known High path; id-unknown fallback with cwd+gitBranch match; **two sessions same cwd different branch** → correct file or ambiguous; >1 match → `ok=false`; missing dir.
+- **Parser — token dedup:** a **multi-block, same-`message.id`** fixture asserting the sum counts the message once (the regression guard for the 2.6× bug). Plus compaction-boundary fixture.
+- **Parser — framing:** a fixture whose last line is a partial append → parser ignores it, returns valid data for the complete prefix, `ok` stays true.
+- **Parser — turn-state:** trailing metadata lines (`mode`, `system`, …) must not flip `TurnOpen`; user-trailing → open; pending-tool → open; assistant-final → closed. Convergence 5-identical / not.
+- **Subagents:** `.meta.json` sidecar parsing; derived status. **Todos:** behind a real fixture (acquire one first).
+- **Pricing:** per-model incl. cache tiers; unknown → 0.
+- **Scan-loop integration (the highest-stakes test):** replay an append-by-append JSONL stream through the actual activity-derivation and assert `processQueue` fires **exactly once per turn** — never zero, never twice — and that the `working`/`convergence` display fields never trigger it.
+- **Race:** run the reader concurrently with a `readLoop`-style writer to `s.LastOutputAt`/`s.Tokens` under `-race`; assert no lock held across I/O.
+- **Fallback:** corrupt complete line + missing file → `ok=false`, no crash, screen-scrape drives state.
 
-## Risks
+## Risks (residual, after fixes)
 
-- **Schema drift:** Claude's JSONL format may change between versions → isolated parsing, tolerant unmarshal, soft fallback.
-- **Cost accuracy:** estimate only, not real Pro/Max billing → label in UI.
-- **Performance:** full-file scan on large sessions → mitigated by the size/mtime cache and byte-level prefilter; full scan runs only on change.
-- **Config override:** `CLAUDE_CONFIG_DIR` must be read from the PTY environment, not assumed to be `~/.claude`.
+- **Schema drift:** Claude's JSONL is undocumented and version-dependent → isolated parser, tolerant unmarshal, soft fallback, fixtures pinned to a known CLI version.
+- **Low-confidence misattribution:** mitigated by cwd+gitBranch matching and the "ambiguous → don't guess" rule; residual risk when two sessions on the same branch+cwd run concurrently without ids → falls back to screen-scrape (acceptable).
+- **Cost accuracy:** estimate only, labeled.
+- **Todos unverified locally** until a real fixture is captured.
 
 ## Follow-ons (out of scope here)
 
-1. Subagent + todo visualization in the pane / future Kanban card.
-2. `linesAdded` / `filesModified` / `gitCommits` / `toolErrors` extraction (same parse pass).
-3. fsnotify watcher subsystem for append-time updates (Approach C).
-4. Multi-provider (Codex/Gemini) session resolution.
+1. Subagent + todo visualization (pane / future Kanban card).
+2. `linesAdded`/`filesModified`/`gitCommits`/`toolErrors`.
+3. fsnotify watcher (replaces the off-loop reader's polling without changing callers).
+4. Multi-provider (Codex/Gemini) resolution.

--- a/internal/backend/app_scan.go
+++ b/internal/backend/app_scan.go
@@ -12,10 +12,12 @@ import (
 
 // ActivityInfo is sent to the frontend when a session's activity state changes.
 type ActivityInfo struct {
-	ID       int    `json:"id"`
-	Activity string `json:"activity"` // "idle", "active", "done", "waitingPermission", "waitingAnswer", "error"
-	Cost     string `json:"cost"`
-	Title    string `json:"title"` // OSC-derived window title (fallback pane name)
+	ID         int    `json:"id"`
+	Activity   string `json:"activity"` // "idle", "active", "done", "waitingPermission", "waitingAnswer", "error"
+	Cost       string `json:"cost"`
+	Title      string `json:"title"`      // OSC-derived window title (fallback pane name)
+	ContextPct int    `json:"contextPct"` // % of context window used (statusline); 0 if unknown
+	Model      string `json:"model"`      // model display name (statusline); "" if unknown
 }
 
 // prevActivity tracks the last emitted state per session to avoid spamming.
@@ -128,6 +130,8 @@ func (a *AppService) scanAllSessions() {
 			costStr = fmt.Sprintf("$%.2f", tokens.TotalCost)
 		}
 
+		ctxPct, model, _ := sess.StatuslineInfo()
+
 		title := sess.GetTitle()
 
 		// Only emit when state, cost, or title actually changed
@@ -146,10 +150,12 @@ func (a *AppService) scanAllSessions() {
 		if changed && a.app != nil {
 			log.Printf("[scan] session %d: activity=%s cost=%s title=%q", id, actStr, costStr, title)
 			a.app.Event.Emit("terminal:activity", ActivityInfo{
-				ID:       id,
-				Activity: actStr,
-				Cost:     costStr,
-				Title:    title,
+				ID:         id,
+				Activity:   actStr,
+				Cost:       costStr,
+				Title:      title,
+				ContextPct: ctxPct,
+				Model:      model,
 			})
 		}
 

--- a/internal/backend/app_scan_test.go
+++ b/internal/backend/app_scan_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
 )
 
+// TestActivityInfoCarriesStatuslineFields guards that the event payload exposes
+// context%/model so the frontend can render them.
+func TestActivityInfoCarriesStatuslineFields(t *testing.T) {
+	info := ActivityInfo{ID: 1, Activity: "active", Cost: "$1.23", ContextPct: 40, Model: "Opus 4.8"}
+	if info.ContextPct != 40 || info.Model != "Opus 4.8" {
+		t.Fatalf("ActivityInfo = %+v, want ContextPct=40 Model=Opus 4.8", info)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // activityString — maps ActivityState to frontend event strings
 // These strings drive the CSS classes for pane border colors:

--- a/internal/backend/app_statusline.go
+++ b/internal/backend/app_statusline.go
@@ -80,7 +80,13 @@ func (a *AppService) applyStatusLine(cfg config.StatusLineSettings) {
 
 	// Use forward slashes so PowerShell resolves the path correctly on Windows.
 	fwdPath := strings.ReplaceAll(scriptPath, `\`, `/`)
-	command := `powershell -NonInteractive -NoProfile -File "` + fwdPath + `"`
+	inner := `powershell -NonInteractive -NoProfile -File "` + fwdPath + `"`
+	// Wrap with the forwarder shim so MTUI captures Claude's statusline telemetry.
+	// If the user already has a statusline, wrap THAT instead so capture still works.
+	if st := a.GetStatusLineStatus(); st.HasExisting && !st.IsOurs && st.ExistingCommand != "" {
+		inner = st.ExistingCommand
+	}
+	command := wrapStatuslineCommand(ensureStatuslineForward(), inner)
 
 	settingsPath := claudeSettingsPath()
 	data, _ := os.ReadFile(settingsPath)

--- a/internal/backend/app_statusline.go
+++ b/internal/backend/app_statusline.go
@@ -86,7 +86,9 @@ func (a *AppService) applyStatusLine(cfg config.StatusLineSettings) {
 	if st := a.GetStatusLineStatus(); st.HasExisting && !st.IsOurs && st.ExistingCommand != "" {
 		inner = st.ExistingCommand
 	}
-	command := wrapStatuslineCommand(ensureStatuslineForward(), inner)
+	fwd := ensureStatuslineForward()
+	command := wrapStatuslineCommand(fwd, inner)
+	log.Printf("[statusline] applyStatusLine: forwarder=%q wrapped=%t command=%q", fwd, fwd != "", command)
 
 	settingsPath := claudeSettingsPath()
 	data, _ := os.ReadFile(settingsPath)

--- a/internal/backend/app_statusline.go
+++ b/internal/backend/app_statusline.go
@@ -83,8 +83,11 @@ func (a *AppService) applyStatusLine(cfg config.StatusLineSettings) {
 	inner := `powershell -NonInteractive -NoProfile -File "` + fwdPath + `"`
 	// Wrap with the forwarder shim so MTUI captures Claude's statusline telemetry.
 	// If the user already has a statusline, wrap THAT instead so capture still works.
+	// Unwrap any existing forwarder prefix first so repeated applyStatusLine calls
+	// (on startup and on every settings save) are idempotent and do not accumulate
+	// nested shim prefixes.
 	if st := a.GetStatusLineStatus(); st.HasExisting && !st.IsOurs && st.ExistingCommand != "" {
-		inner = st.ExistingCommand
+		inner = unwrapStatuslineCommand(st.ExistingCommand)
 	}
 	fwd := ensureStatuslineForward()
 	command := wrapStatuslineCommand(fwd, inner)

--- a/internal/backend/app_statusline_api.go
+++ b/internal/backend/app_statusline_api.go
@@ -43,6 +43,8 @@ func (a *AppService) handleStatusline(w http.ResponseWriter, r *http.Request) {
 	sess := a.sessions[p.SessionID]
 	a.mu.Unlock()
 	if sess != nil {
+		// int(UsedPercentage) intentionally truncates: 40.9 → 40. Exact decimal
+		// precision is not required for the progress-bar display.
 		sess.SetStatuslineData(
 			p.Payload.Cost.TotalCostUSD,
 			int(p.Payload.ContextWindow.UsedPercentage),

--- a/internal/backend/app_statusline_api.go
+++ b/internal/backend/app_statusline_api.go
@@ -3,6 +3,7 @@ package backend
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 )
 
@@ -48,6 +49,9 @@ func (a *AppService) handleStatusline(w http.ResponseWriter, r *http.Request) {
 			p.Payload.Model.DisplayName,
 		)
 	}
+	log.Printf("[statusline] session %d cost=%.4f ctx=%d%% model=%q found=%t",
+		p.SessionID, p.Payload.Cost.TotalCostUSD,
+		int(p.Payload.ContextWindow.UsedPercentage), p.Payload.Model.DisplayName, sess != nil)
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/backend/app_statusline_api.go
+++ b/internal/backend/app_statusline_api.go
@@ -1,0 +1,53 @@
+// internal/backend/app_statusline_api.go
+package backend
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// statuslinePayload is MTUI's wrapper around Claude's raw statusLine JSON,
+// posted by the statusline-forward shim. Only the fields MTUI consumes are typed;
+// unknown fields are ignored.
+type statuslinePayload struct {
+	SessionID int `json:"sessionId"`
+	Payload   struct {
+		Cost struct {
+			TotalCostUSD  float64 `json:"total_cost_usd"`
+			TotalDuration int     `json:"total_duration_ms"`
+		} `json:"cost"`
+		ContextWindow struct {
+			UsedPercentage float64 `json:"used_percentage"`
+		} `json:"context_window"`
+		Model struct {
+			DisplayName string `json:"display_name"`
+		} `json:"model"`
+	} `json:"payload"`
+}
+
+// handleStatusline records cost/context/model from a forwarded statusLine update.
+// Loopback-only, POST-only, no auth (same trust model as /api/tmux/log).
+func (a *AppService) handleStatusline(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	var p statuslinePayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	a.mu.Lock()
+	sess := a.sessions[p.SessionID]
+	a.mu.Unlock()
+	if sess != nil {
+		sess.SetStatuslineData(
+			p.Payload.Cost.TotalCostUSD,
+			int(p.Payload.ContextWindow.UsedPercentage),
+			p.Payload.Model.DisplayName,
+		)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/backend/app_statusline_api_test.go
+++ b/internal/backend/app_statusline_api_test.go
@@ -1,0 +1,54 @@
+// internal/backend/app_statusline_api_test.go
+package backend
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/patrick-goecommerce/Multiterminal-UI/internal/terminal"
+)
+
+func TestHandleStatuslineUpdatesSession(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	sess := terminal.NewSession(5, 24, 80)
+	a.sessions[5] = sess
+
+	body := `{"sessionId":5,"payload":{"cost":{"total_cost_usd":1.23},` +
+		`"context_window":{"used_percentage":40},"model":{"display_name":"Opus 4.8"}}}`
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	a.handleStatusline(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := sess.GetTokens().TotalCost; got != 1.23 {
+		t.Fatalf("TotalCost = %v, want 1.23", got)
+	}
+	pct, model, src := sess.StatuslineInfo()
+	if pct != 40 || model != "Opus 4.8" || src != terminal.CostSourceStatusline {
+		t.Fatalf("StatuslineInfo = (%d,%q,%d), want (40,Opus 4.8,statusline)", pct, model, src)
+	}
+}
+
+func TestHandleStatuslineUnknownSessionNoCrash(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(`{"sessionId":99,"payload":{}}`))
+	rec := httptest.NewRecorder()
+	a.handleStatusline(rec, req) // must not panic
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandleStatuslineGarbageBodyIsBadRequest(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(`not json`))
+	rec := httptest.NewRecorder()
+	a.handleStatusline(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/internal/backend/app_statusline_api_test.go
+++ b/internal/backend/app_statusline_api_test.go
@@ -52,3 +52,30 @@ func TestHandleStatuslineGarbageBodyIsBadRequest(t *testing.T) {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 }
+
+func TestHandleStatuslineNonPostReturns405(t *testing.T) {
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	req := httptest.NewRequest("GET", "/api/statusline", nil)
+	rec := httptest.NewRecorder()
+	a.handleStatusline(rec, req)
+	if rec.Code != 405 {
+		t.Fatalf("status = %d, want 405 for GET", rec.Code)
+	}
+}
+
+func TestHandleStatuslineFractionalPercentageTruncates(t *testing.T) {
+	// float64 40.9 must truncate to int 40 (not round to 41).
+	a := &AppService{sessions: map[int]*terminal.Session{}}
+	sess := terminal.NewSession(7, 24, 80)
+	a.sessions[7] = sess
+
+	body := `{"sessionId":7,"payload":{"context_window":{"used_percentage":40.9}}}`
+	req := httptest.NewRequest("POST", "/api/statusline", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	a.handleStatusline(rec, req)
+
+	pct, _, _ := sess.StatuslineInfo()
+	if pct != 40 {
+		t.Fatalf("context pct = %d, want 40 (truncated from 40.9)", pct)
+	}
+}

--- a/internal/backend/app_statusline_wrap.go
+++ b/internal/backend/app_statusline_wrap.go
@@ -1,0 +1,79 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// statuslineForwardSiblingPath returns the path to a statusline-forward shim
+// sitting next to the running binary (the dev / E2E build layout where both land
+// in build/bin/). Returns "" if no sibling shim exists.
+func statuslineForwardSiblingPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	name := "statusline-forward"
+	if filepath.Ext(exe) == ".exe" {
+		name += ".exe"
+	}
+	p := filepath.Join(filepath.Dir(exe), name)
+	if _, err := os.Stat(p); err != nil {
+		return ""
+	}
+	return filepath.ToSlash(p)
+}
+
+// statuslineForwardExtractPath returns the writable location the embedded shim is
+// extracted to for production (single-portable-exe) builds: alongside the
+// statusline script in the user's ~/.claude dir, which MTUI already writes to.
+func statuslineForwardExtractPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".claude", "mtui-statusline-forward.exe")
+}
+
+// extractShim writes the embedded shim bytes to dst, returning the path to the
+// extracted file. It is a no-op (returns "") when data is empty — the non-
+// production build embeds nothing, so the sibling path is used instead. If a file
+// of the same size already exists it is left untouched (avoids rewriting / a
+// sharing violation on a shim that may be mid-invocation on Windows).
+func extractShim(dst string, data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+	if fi, err := os.Stat(dst); err == nil && fi.Size() == int64(len(data)) {
+		return dst, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(dst, data, 0755); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+// ensureStatuslineForward resolves the statusline-forward shim path, preferring a
+// sibling binary (dev/E2E) and falling back to extracting the embedded shim
+// (production). Returns "" when no shim is available, in which case the
+// statusline is registered unwrapped (fail-safe).
+func ensureStatuslineForward() string {
+	if p := statuslineForwardSiblingPath(); p != "" {
+		return p
+	}
+	p, err := extractShim(statuslineForwardExtractPath(), shimBin)
+	if err != nil {
+		return ""
+	}
+	return filepath.ToSlash(p)
+}
+
+// wrapStatuslineCommand builds the statusLine.command string: the quoted
+// forwarder followed by the inner (real) statusline command it wraps. If
+// forwarder is "", the inner command is returned unchanged (fail-safe).
+func wrapStatuslineCommand(forwarder, inner string) string {
+	if forwarder == "" {
+		return inner
+	}
+	return `"` + forwarder + `" ` + inner
+}

--- a/internal/backend/app_statusline_wrap.go
+++ b/internal/backend/app_statusline_wrap.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // statuslineForwardSiblingPath returns the path to a statusline-forward shim
@@ -76,4 +77,33 @@ func wrapStatuslineCommand(forwarder, inner string) string {
 		return inner
 	}
 	return `"` + forwarder + `" ` + inner
+}
+
+// unwrapStatuslineCommand strips a forwarder prefix from cmd if the first
+// quoted token's basename is "statusline-forward" or "statusline-forward.exe".
+// This makes re-wrapping idempotent: applyStatusLine can call it on an
+// existing user statusline command without accumulating nested shim prefixes
+// across restarts or settings saves. The match is done on the basename alone
+// so it is robust to path differences between dev (sibling) and production
+// (extracted temp dir) runs.
+func unwrapStatuslineCommand(cmd string) string {
+	if len(cmd) == 0 || cmd[0] != '"' {
+		return cmd
+	}
+	// Find the closing quote of the first token.
+	end := strings.Index(cmd[1:], `"`)
+	if end < 0 {
+		return cmd
+	}
+	firstToken := cmd[1 : end+1] // path inside the quotes
+	base := strings.ToLower(filepath.Base(firstToken))
+	if base != "statusline-forward.exe" && base != "statusline-forward" {
+		return cmd
+	}
+	// Strip the quoted token and the single space that follows it.
+	rest := cmd[end+2:] // skip closing quote
+	if strings.HasPrefix(rest, " ") {
+		rest = rest[1:]
+	}
+	return rest
 }

--- a/internal/backend/app_statusline_wrap_test.go
+++ b/internal/backend/app_statusline_wrap_test.go
@@ -7,6 +7,62 @@ import (
 	"testing"
 )
 
+// --- unwrapStatuslineCommand tests ---
+
+func TestUnwrapStatuslineCommandStripsForwarderPrefix(t *testing.T) {
+	// The prefix path differs from the "current" path (different drive/dir) — must
+	// still be stripped because matching is done on the basename only.
+	wrapped := `"C:/old/build/bin/statusline-forward.exe" powershell -File "C:/Users/x/.claude/foo.ps1"`
+	got := unwrapStatuslineCommand(wrapped)
+	want := `powershell -File "C:/Users/x/.claude/foo.ps1"`
+	if got != want {
+		t.Fatalf("unwrapStatuslineCommand(%q) = %q, want %q", wrapped, got, want)
+	}
+}
+
+func TestUnwrapStatuslineCommandLeavesPlainCommandUnchanged(t *testing.T) {
+	plain := `powershell -NonInteractive -File "C:/Users/x/.claude/mtui-statusline.ps1"`
+	got := unwrapStatuslineCommand(plain)
+	if got != plain {
+		t.Fatalf("unwrapStatuslineCommand(%q) = %q, want unchanged", plain, got)
+	}
+}
+
+func TestUnwrapStatuslineCommandLeavesUnrelatedQuotedCommandUnchanged(t *testing.T) {
+	other := `"C:/some/other/tool.exe" arg1 arg2`
+	got := unwrapStatuslineCommand(other)
+	if got != other {
+		t.Fatalf("unwrapStatuslineCommand(%q) = %q, want unchanged", other, got)
+	}
+}
+
+func TestWrapAfterUnwrapIsIdempotent(t *testing.T) {
+	forwarder := `C:/new/build/bin/statusline-forward.exe`
+	userCmd := `powershell -File "C:/Users/x/.claude/my-status.ps1"`
+
+	// Simulate what was persisted to settings.json by a previous run.
+	alreadyWrapped := wrapStatuslineCommand(forwarder, userCmd)
+
+	// applyStatusLine unwraps then re-wraps — the result must have exactly one
+	// forwarder prefix, not two.
+	inner := unwrapStatuslineCommand(alreadyWrapped)
+	rewrapped := wrapStatuslineCommand(forwarder, inner)
+
+	// Exactly one quoted forwarder prefix.
+	prefix := `"` + forwarder + `" `
+	if !strings.HasPrefix(rewrapped, prefix) {
+		t.Fatalf("rewrapped %q does not start with %q", rewrapped, prefix)
+	}
+	// The inner command must appear exactly once (no double-nesting).
+	if strings.Count(rewrapped, userCmd) != 1 {
+		t.Fatalf("rewrapped %q contains userCmd %d time(s), want 1", rewrapped, strings.Count(rewrapped, userCmd))
+	}
+	// Shape must equal alreadyWrapped (idempotent).
+	if rewrapped != alreadyWrapped {
+		t.Fatalf("rewrapped %q != original %q", rewrapped, alreadyWrapped)
+	}
+}
+
 func TestWrapStatuslineCommandPrependsForwarder(t *testing.T) {
 	inner := `powershell -NonInteractive -NoProfile -File "C:/Users/x/.claude/mtui-statusline.ps1"`
 	got := wrapStatuslineCommand(`C:/Users/x/AppData/.../statusline-forward.exe`, inner)

--- a/internal/backend/app_statusline_wrap_test.go
+++ b/internal/backend/app_statusline_wrap_test.go
@@ -1,0 +1,80 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWrapStatuslineCommandPrependsForwarder(t *testing.T) {
+	inner := `powershell -NonInteractive -NoProfile -File "C:/Users/x/.claude/mtui-statusline.ps1"`
+	got := wrapStatuslineCommand(`C:/Users/x/AppData/.../statusline-forward.exe`, inner)
+
+	if !strings.HasPrefix(got, `"C:/Users/x/AppData/.../statusline-forward.exe" `) {
+		t.Fatalf("command = %q, want it to start with the quoted forwarder path", got)
+	}
+	if !strings.HasSuffix(got, inner) {
+		t.Fatalf("command = %q, want it to end with the wrapped inner command %q", got, inner)
+	}
+}
+
+func TestWrapStatuslineCommandEmptyForwarderReturnsInner(t *testing.T) {
+	// Fail-safe: no forwarder available -> register the inner command unchanged.
+	inner := `powershell -File foo.ps1`
+	if got := wrapStatuslineCommand("", inner); got != inner {
+		t.Fatalf("command = %q, want unchanged inner %q", got, inner)
+	}
+}
+
+func TestExtractShimWritesAndReturnsPath(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "shim.exe")
+	data := []byte("MZ-fake-binary")
+
+	got, err := extractShim(dst, data)
+	if err != nil {
+		t.Fatalf("extractShim error: %v", err)
+	}
+	if got != dst {
+		t.Fatalf("path = %q, want %q", got, dst)
+	}
+	on, _ := os.ReadFile(dst)
+	if string(on) != string(data) {
+		t.Fatalf("written content = %q, want %q", on, data)
+	}
+}
+
+func TestExtractShimEmptyDataReturnsEmpty(t *testing.T) {
+	// No embedded shim (dev/non-production build): nothing extracted, no path.
+	dst := filepath.Join(t.TempDir(), "shim.exe")
+	got, err := extractShim(dst, nil)
+	if err != nil {
+		t.Fatalf("extractShim error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("path = %q, want empty", got)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("file should not exist, stat err = %v", err)
+	}
+}
+
+func TestExtractShimIdempotentWhenSameSize(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "shim.exe")
+	data := []byte("same-size-content")
+	if _, err := extractShim(dst, data); err != nil {
+		t.Fatalf("first extract: %v", err)
+	}
+	// Second call with identical-size data must succeed and keep the file intact.
+	got, err := extractShim(dst, data)
+	if err != nil {
+		t.Fatalf("second extract: %v", err)
+	}
+	if got != dst {
+		t.Fatalf("path = %q, want %q", got, dst)
+	}
+	on, _ := os.ReadFile(dst)
+	if string(on) != string(data) {
+		t.Fatalf("content = %q, want %q", on, data)
+	}
+}

--- a/internal/backend/app_tmux_api.go
+++ b/internal/backend/app_tmux_api.go
@@ -20,6 +20,7 @@ type TmuxLogEntry struct {
 func (a *AppService) startTmuxAPI() (int, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/tmux/log", a.handleTmuxLog)
+	mux.HandleFunc("/api/statusline", a.handleStatusline)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/backend/statusline_shim_embed.go
+++ b/internal/backend/statusline_shim_embed.go
@@ -1,0 +1,15 @@
+//go:build production
+
+package backend
+
+import _ "embed"
+
+// shimBin is the statusline-forward shim, embedded into the production
+// (single-portable-exe) build. It is extracted at runtime next to the statusline
+// script (see ensureStatuslineForward). The release pipeline MUST build
+// ./cmd/statusline-forward into internal/backend/statusline-forward.exe before
+// building the main binary with `-tags production`, or this embed fails to find
+// the file.
+//
+//go:embed statusline-forward.exe
+var shimBin []byte

--- a/internal/backend/statusline_shim_noembed.go
+++ b/internal/backend/statusline_shim_noembed.go
@@ -1,0 +1,8 @@
+//go:build !production
+
+package backend
+
+// shimBin is empty in non-production builds (dev / CI `go build ./...`). The
+// statusline-forward shim is then located as a sibling binary instead of being
+// extracted. The production build (statusline_shim_embed.go) embeds the real exe.
+var shimBin []byte

--- a/internal/terminal/activity.go
+++ b/internal/terminal/activity.go
@@ -46,10 +46,13 @@ func (s *Session) ScanTokens() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Look for cost patterns like $0.12 or $1.50
-	if matches := costPattern.FindStringSubmatch(content); len(matches) >= 2 {
-		if v, err := strconv.ParseFloat(matches[1], 64); err == nil {
-			s.Tokens.TotalCost = v
+	// Look for cost patterns like $0.12 or $1.50 — but never overwrite an
+	// authoritative statusline-sourced cost.
+	if s.costSource != CostSourceStatusline {
+		if matches := costPattern.FindStringSubmatch(content); len(matches) >= 2 {
+			if v, err := strconv.ParseFloat(matches[1], 64); err == nil {
+				s.Tokens.TotalCost = v
+			}
 		}
 	}
 

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -63,10 +63,9 @@ type Session struct {
 
 	// Statusline-sourced telemetry (Claude's statusLine JSON via the forwarder shim).
 	// When costSource == CostSourceStatusline, the screen scrape must not overwrite cost.
-	statuslineCost float64
-	contextPct     int
-	model          string
-	costSource     CostSource
+	contextPct int
+	model      string
+	costSource CostSource
 
 	// hookSessionID / hasHookData: set by Claude Code hook events.
 	// hasHookData=true means the scan loop skips DetectActivity() for this session.

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -60,6 +60,14 @@ type Session struct {
 
 	// Tokens holds parsed token usage / cost information.
 	Tokens TokenInfo
+
+	// Statusline-sourced telemetry (Claude's statusLine JSON via the forwarder shim).
+	// When costSource == CostSourceStatusline, the screen scrape must not overwrite cost.
+	statuslineCost float64
+	contextPct     int
+	model          string
+	costSource     CostSource
+
 	// hookSessionID / hasHookData: set by Claude Code hook events.
 	// hasHookData=true means the scan loop skips DetectActivity() for this session.
 	hookSessionID string

--- a/internal/terminal/session_statusline.go
+++ b/internal/terminal/session_statusline.go
@@ -1,0 +1,31 @@
+package terminal
+
+// CostSource records which source last set the session's cost, so the screen
+// scrape (ScanTokens) does not clobber an authoritative statusline value.
+type CostSource int
+
+const (
+	CostSourceScrape     CostSource = iota // cost derived from screen scraping
+	CostSourceStatusline                   // cost from Claude's statusLine JSON
+)
+
+// SetStatuslineData records official cost/context/model from Claude's statusLine
+// and marks the statusline as the authoritative cost source. Called from the
+// /api/statusline HTTP handler; assignment only, no I/O under the lock.
+func (s *Session) SetStatuslineData(cost float64, contextPct int, model string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuslineCost = cost
+	s.contextPct = contextPct
+	s.model = model
+	s.costSource = CostSourceStatusline
+	s.Tokens.TotalCost = cost // single displayed cost field stays authoritative
+}
+
+// StatuslineInfo returns the statusline-sourced context%/model and the current
+// cost source.
+func (s *Session) StatuslineInfo() (contextPct int, model string, src CostSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.contextPct, s.model, s.costSource
+}

--- a/internal/terminal/session_statusline.go
+++ b/internal/terminal/session_statusline.go
@@ -15,7 +15,6 @@ const (
 func (s *Session) SetStatuslineData(cost float64, contextPct int, model string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.statuslineCost = cost
 	s.contextPct = contextPct
 	s.model = model
 	s.costSource = CostSourceStatusline

--- a/internal/terminal/session_statusline_test.go
+++ b/internal/terminal/session_statusline_test.go
@@ -1,0 +1,41 @@
+// internal/terminal/session_statusline_test.go
+package terminal
+
+import "testing"
+
+func TestSetStatuslineDataSetsFieldsAndSource(t *testing.T) {
+	s := NewSession(1, 24, 80)
+	s.SetStatuslineData(0.42, 35, "claude-opus-4-8")
+
+	if got := s.GetTokens().TotalCost; got != 0.42 {
+		t.Fatalf("TotalCost = %v, want 0.42", got)
+	}
+	pct, model, src := s.StatuslineInfo()
+	if pct != 35 || model != "claude-opus-4-8" || src != CostSourceStatusline {
+		t.Fatalf("StatuslineInfo() = (%d,%q,%d), want (35,claude-opus-4-8,statusline)", pct, model, src)
+	}
+}
+
+func TestScanTokensDoesNotOverwriteStatuslineCost(t *testing.T) {
+	s := NewSession(1, 24, 80)
+	s.SetStatuslineData(0.42, 0, "")
+	// Put a different cost on screen; the scrape must NOT win.
+	_, _ = s.Screen.Write([]byte("context left: $0.99\r\n"))
+
+	s.ScanTokens()
+
+	if got := s.GetTokens().TotalCost; got != 0.42 {
+		t.Fatalf("TotalCost = %v after ScanTokens, want 0.42 (statusline authoritative)", got)
+	}
+}
+
+func TestScanTokensStillScrapesWhenNoStatusline(t *testing.T) {
+	s := NewSession(1, 5, 80) // small screen so row 0 falls within the last-10-row scan window
+	_, _ = s.Screen.Write([]byte("cost: $0.99\r\n"))
+
+	s.ScanTokens()
+
+	if got := s.GetTokens().TotalCost; got != 0.99 {
+		t.Fatalf("TotalCost = %v, want 0.99 (scrape active)", got)
+	}
+}


### PR DESCRIPTION
## Was

Erfasst Claudes **offizielle** Kosten / Kontext-% / Modell pro Pane, indem MTUIs eigene Statusline mit einem Go-Forwarder-Shim umhüllt wird: der Shim leitet Claudes Statusline-JSON an einen lokalen `/api/statusline`-Endpoint weiter. Der Handler schreibt die Werte auf die `Session` und markiert `costSource=statusline`, sodass das bisherige Screen-Scraping sie nicht überschreibt. Das Aktivitäts-Event trägt nun Kontext-% und Modell.

Erster „Steal" aus der Agent-Dashboard-Analyse (JSONL-Reader-Idee → statusline-primär nach Spike). Spec: `docs/superpowers/specs/2026-06-23-claudelog-jsonl-reader-design.md` (Rev 4). Plan: `docs/superpowers/plans/2026-06-23-statusline-capture.md`.

## Warum statusline statt JSONL-Transkript

Eine unvorgeprägte („clean start") Review-Runde kippte den ursprünglichen JSONL-Transkript-Ansatz: er hätte die Kosten um ~40 % **unterzählt** (Subagenten-Spend liegt in separaten Dateien), während drei billigere, bereits integrierte Quellen ungenutzt im Code lagen. Ein verifizierter Spike zeigte: die Statusline liefert die amtliche `total_cost_usd` (inkl. Subagenten), die Pane-Zuordnung ist gratis über `MULTITERMINAL_SESSION_ID` (PTY-Env), und der Rückkanal (localhost-HTTP auf `MTUI_PORT`) existiert bereits. Das eliminiert Encoder, Datei-Resolver und Pricing-Tabelle.

## Wesentliche Eigenschaften

- **Forwarder-Shim** (`cmd/statusline-forward`): leitet die umhüllte Statusline durch (Anzeige unverändert), POSTet best-effort, fail-silent. Per `go:embed` in die Binary eingebettet (Abweichung vom Plan — akzeptiert, da MTUI als single portable `.exe` ausgeliefert wird).
- **Umhüllt eine bestehende Nutzer-Statusline** (tee) statt sie zu ersetzen — und ist **idempotent** (kein Double-Wrap-Aufschaukeln über App-Starts/Settings-Saves).
- **`active→done`-Pipeline-Kante unverändert** (verifiziert) — die Queue liest nie Token-State.
- Konsolen-Fenster-Flash des Shims unter Windows unterdrückt (korrekt build-getaggt).
- Lock-Disziplin sauber (kein Lock über I/O), `go test ./...` grün, `go vet` sauber.

## Qualitäts-Historie

4 Spec-Revisionen, 3 vorgeprägte Red-Team-Runden (härteten Detail), 1 Clean-Start-Runde (kippte die Datenquelle), Spike, gehärtete Rev 4, dann Subagent-Driven-Umsetzung (Implementer + Review pro Task) und ein finales Whole-Branch-Review (Opus) → „With fixes": Double-Wrap-Idempotenz-Bug gefixt + Regressionstests, Minors (405-Test, Trunkierungs-Doku, stdin-Kommentar, Build-Doku) eingearbeitet.

## ⚠️ needs-e2e-testing

Code vollständig, reviewed, unit-grün — aber der **reale Flow wurde nie E2E getestet** (laufende GUI + echtes Claude: Statusline-Capture greift, Pane zeigt amtliche Kosten/Modell, `settings.json` enthält genau **einen** Shim-Prefix, kein Hänger/Flash). Der Double-Wrap-Fix hat den Wrap-Pfad zuletzt geändert → vor dem Merge nach `alpha-main` muss der E2E-Smoke laufen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
